### PR TITLE
Switch to Stream API

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
@@ -147,7 +147,7 @@
             context.TryGet<string>("cosmosdb_etag", out var etag);
             var options = new ItemRequestOptions { IfMatchEtag = etag };
 
-            return container.DeleteItemAsync<dynamic>(sagaData.Id.ToString(), new PartitionKey(partitionKey), options);
+            return container.DeleteItemStreamAsync(sagaData.Id.ToString(), new PartitionKey(partitionKey), options);
         }
     }
 

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
@@ -41,10 +41,10 @@
             jObject.Add("SagaDataTypeVersion", FileVersionRetriever.GetFileVersion(sagaDataType));
 
             using (var stream = new MemoryStream())
-            using (StreamWriter sw = new StreamWriter(stream))
-            using (JsonWriter writer = new JsonTextWriter(sw))
+            using (var streamWriter = new StreamWriter(stream))
+            using (JsonWriter jsonWriter = new JsonTextWriter(streamWriter))
             {
-                await jObject.WriteToAsync(writer).ConfigureAwait(false);
+                await jObject.WriteToAsync(jsonWriter).ConfigureAwait(false);
 
                 await container.CreateItemStreamAsync(stream, new PartitionKey(partitionKey)).ConfigureAwait(false);
             }


### PR DESCRIPTION
Bob and I took on a transient Newtonsoft.Json dependency used by CosmosDB.
We should consider providing a configuration API for the persistence to take a custom serializer settings to pass on to CosmosDB client the persistence will use.

I've left the idea to delete items using TTL out of this PR but we could take the similar approach to the one used in the `Save` method, adding a property `ttl` with the desired amount of time (in seconds) after which the item should be auto-deleted.