### PR TITLE
Replace RoutingSettings with PersistenceExtensions  for settings

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Threading;
-    using System.Threading.Tasks;P
+    using System.Threading.Tasks;
     using Logging;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Fluent;
@@ -43,8 +43,8 @@
             }
 
             // TODO: Finish
-            var routingSettings = new RoutingSettings(new SettingsHolder());
-            var config = new PartitionAwareConfiguration(routingSettings);
+            var persistenceSettings = new PersistenceExtensions<CosmosDbPersistence>(new SettingsHolder());
+            var config = new PartitionAwareConfiguration(persistenceSettings);
             // config.MapMessageToContainer()
 
             SynchronizedStorage = new StorageSessionFactory(databaseName, cosmosDbClient, config);

--- a/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -51,6 +51,11 @@
             cosmosDbClient = builder.Build();
             SagaStorage = new SagaPersister(new JsonSerializerSettings(), cosmosDbClient, databaseName);
 
+            // TODO: Finish
+            // var routingSettings = new RoutingSettings(new SettingsHolder());
+            // var config = new PartitionAwareConfiguration(routingSettings);
+            // config.MapMessageToContainer()
+
             await cosmosDbClient.CreateDatabaseIfNotExistsAsync(databaseName);
             await cosmosDbClient.PopulateContainers(databaseName, SagaMetadataCollection);
         }

--- a/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -2,8 +2,7 @@
 {
     using System;
     using System.Threading;
-    using System.Threading.Tasks;
-    using Features;
+    using System.Threading.Tasks;P
     using Logging;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Fluent;
@@ -11,8 +10,8 @@
     using NServiceBus.Outbox;
     using NServiceBus.Sagas;
     using Persistence;
-    using Persistence.ComponentTests;
     using Persistence.CosmosDB;
+    using Settings;
 
     public partial class PersistenceTestsConfiguration
     {
@@ -43,21 +42,21 @@
                 throw new Exception($"Oh no! We couldn't find an environment variable '{connectionStringEnvironmentVariableName}' with Cosmos DB connection string.");
             }
 
-            SynchronizedStorage = new SynchronizedStorageForTesting();
+            // TODO: Finish
+            var routingSettings = new RoutingSettings(new SettingsHolder());
+            var config = new PartitionAwareConfiguration(routingSettings);
+            // config.MapMessageToContainer()
+
+            SynchronizedStorage = new StorageSessionFactory(databaseName, cosmosDbClient, config);
 
             var builder = new CosmosClientBuilder(connectionString);
             builder.AddCustomHandlers(new LoggingHandler());
 
             cosmosDbClient = builder.Build();
-            SagaStorage = new SagaPersister(new JsonSerializerSettings(), cosmosDbClient, databaseName);
-
-            // TODO: Finish
-            // var routingSettings = new RoutingSettings(new SettingsHolder());
-            // var config = new PartitionAwareConfiguration(routingSettings);
-            // config.MapMessageToContainer()
+            SagaStorage = new SagaPersister(new JsonSerializerSettings());
 
             await cosmosDbClient.CreateDatabaseIfNotExistsAsync(databaseName);
-            await cosmosDbClient.PopulateContainers(databaseName, SagaMetadataCollection);
+            //await cosmosDbClient.PopulateContainers(databaseName, SagaMetadataCollection);
         }
 
         public async Task Cleanup()

--- a/src/NServiceBus.Persistence.CosmosDB/Config/ContainerAndPartition.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/ContainerAndPartition.cs
@@ -1,0 +1,89 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System;
+
+    /// <summary>
+    ///
+    /// </summary>
+    public readonly struct ContainerAndPartition
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        public bool Equals(ContainerAndPartition other)
+        {
+            return string.Equals(PartitionKey, other.PartitionKey, StringComparison.OrdinalIgnoreCase) && string.Equals(Container, other.Container, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns></returns>
+        public override bool Equals(object obj)
+        {
+            return obj is ContainerAndPartition other && Equals(other);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((PartitionKey != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(PartitionKey) : 0) * 397) ^ (Container != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(Container) : 0);
+            }
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator ==(ContainerAndPartition left, ContainerAndPartition right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <returns></returns>
+        public static bool operator !=(ContainerAndPartition left, ContainerAndPartition right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public string PartitionKey { get; }
+        /// <summary>
+        ///
+        /// </summary>
+        public string Container { get; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="container"></param>
+        /// <param name="partitionKey"></param>
+        public ContainerAndPartition(string container, string partitionKey)
+        {
+            PartitionKey = partitionKey;
+            Container = container;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public static ContainerAndPartition None { get; } = new ContainerAndPartition(null, null);
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB/Config/CosmosDbPersistenceConfig.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/CosmosDbPersistenceConfig.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using System;
     using Configuration.AdvancedExtensibility;
     using Microsoft.Azure.Cosmos;
     using Persistence.CosmosDB;
@@ -11,25 +10,38 @@
     public static partial class CosmosDbPersistenceConfig
     {
         /// <summary>
-        /// Override the default MongoClient creation by providing a pre-configured IMongoClient
+        /// Override the default CosmosClient creation by providing a pre-configured CosmosClient
         /// </summary>
-        public static PersistenceExtensions<CosmosDbPersistence> MongoClient(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions, CosmosClient cosmosClient)
+        public static PersistenceExtensions<CosmosDbPersistence> CosmosClient(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions, CosmosClient cosmosClient)
         {
             Guard.AgainstNull(nameof(persistenceExtensions), persistenceExtensions);
             Guard.AgainstNull(nameof(cosmosClient), cosmosClient);
 
-            persistenceExtensions.GetSettings().Set(SettingsKeys.CosmosClient, (Func<CosmosClient>)(() => cosmosClient));
+            persistenceExtensions.GetSettings().Set(SettingsKeys.CosmosClient, cosmosClient);
             return persistenceExtensions;
         }
 
         /// <summary>
         /// Connection string to use for sagas storage.
         /// </summary>
+        /// TODO: Discuss if we can drop this in favor of just providing CosmosClient above.
         public static PersistenceExtensions<CosmosDbPersistence> ConnectionString(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions, string connectionString)
         {
             Guard.AgainstNullAndEmpty(nameof(connectionString), connectionString);
 
-            persistenceExtensions.GetSettings().Set(SettingsKeys.ConnectionString, connectionString);
+            persistenceExtensions.GetSettings().Set(SettingsKeys.CosmosClient, new CosmosClient(connectionString));
+
+            return persistenceExtensions;
+        }
+
+        /// <summary>
+        /// Sets the database name
+        /// </summary>
+        public static PersistenceExtensions<CosmosDbPersistence> DatabaseName(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions, string databaseName)
+        {
+            Guard.AgainstNullAndEmpty(nameof(databaseName), databaseName);
+
+            persistenceExtensions.GetSettings().Set(SettingsKeys.DatabaseName, databaseName);
 
             return persistenceExtensions;
         }

--- a/src/NServiceBus.Persistence.CosmosDB/Config/Map.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/Map.cs
@@ -1,0 +1,13 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos;
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="headers"></param>
+    /// <param name="messageId"></param>
+    /// <param name="message"></param>
+    public delegate PartitionKey Map(IReadOnlyDictionary<string, string> headers, string messageId, object message);
+}

--- a/src/NServiceBus.Persistence.CosmosDB/Config/PartitionAwareConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/PartitionAwareConfiguration.cs
@@ -1,0 +1,60 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System;
+    using System.Collections.Generic;
+    using Configuration.AdvancedExtensibility;
+    using Microsoft.Azure.Cosmos;
+
+    /// <summary>
+    ///
+    /// </summary>
+    public class PartitionAwareConfiguration :
+        ExposeSettings
+    {
+        Dictionary<Type, Map> typeToPartitionMappers = new Dictionary<Type, Map>();
+        Dictionary<Type, string> typeToContainerMappers = new Dictionary<Type, string>();
+
+        internal PartitionAwareConfiguration(RoutingSettings routingSettings)
+            : base(routingSettings.GetSettings())
+        {
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="map"></param>
+        /// <param name="containerName"></param>
+        /// <typeparam name="T"></typeparam>
+        public void AddPartitionMappingForMessageType<T>(Map map, string containerName)
+        {
+            typeToPartitionMappers[typeof(T)] = (headers, messageId, message) => map(headers, messageId, (T)message);
+            typeToContainerMappers[typeof(T)] = containerName;
+        }
+
+        internal string MapMessageToContainer(Type messageType)
+        {
+            if (!typeToContainerMappers.TryGetValue(messageType, out var containerName))
+            {
+                throw new Exception($"No container name mapping is found for message type '{messageType}'.");
+            }
+
+            return containerName;
+        }
+
+        internal PartitionKey MapMessageToPartition(IReadOnlyDictionary<string, string> headers, string messageId, Type messageType, object message)
+        {
+            if (!typeToPartitionMappers.TryGetValue(messageType, out var mapper))
+            {
+                throw new Exception($"No partition mapping is found for message type '{messageType}'.");
+            }
+
+            var partitionKey = mapper(headers, messageId, message);
+
+            if (partitionKey != PartitionKey.None)
+            {
+                return partitionKey;
+            }
+            throw new Exception($"Partition '{partitionKey}' returned by partition mapping of '{messageType}' did not return a result.");
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB/Config/PartitionAwareConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/PartitionAwareConfiguration.cs
@@ -8,14 +8,12 @@
     /// <summary>
     ///
     /// </summary>
-    public class PartitionAwareConfiguration :
-        ExposeSettings
+    public class PartitionAwareConfiguration : ExposeSettings
     {
         Dictionary<Type, Map> typeToPartitionMappers = new Dictionary<Type, Map>();
         Dictionary<Type, string> typeToContainerMappers = new Dictionary<Type, string>();
 
-        internal PartitionAwareConfiguration(RoutingSettings routingSettings)
-            : base(routingSettings.GetSettings())
+        internal PartitionAwareConfiguration(PersistenceExtensions<CosmosDbPersistence> persistenceSettings) : base(persistenceSettings.GetSettings())
         {
         }
 

--- a/src/NServiceBus.Persistence.CosmosDB/Config/PartitionAwareRoutingExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/PartitionAwareRoutingExtensions.cs
@@ -1,0 +1,32 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using Configuration.AdvancedExtensibility;
+    using Transport;
+
+    /// <summary>
+    ///
+    /// </summary>
+    public static class PartitionAwareRoutingExtensions
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="routingSettings"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static PartitionAwareConfiguration Partition<T>(this RoutingSettings<T> routingSettings) where T : TransportDefinition
+        {
+            var settings = routingSettings.GetSettings();
+
+            if (settings.TryGet(out PartitionAwareConfiguration config))
+            {
+                return config;
+            }
+
+            config = new PartitionAwareConfiguration(routingSettings);
+            settings.Set(config);
+
+            return config;
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB/Config/PartitionAwareRoutingExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/PartitionAwareRoutingExtensions.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Persistence.CosmosDB
 {
     using Configuration.AdvancedExtensibility;
-    using Transport;
 
     /// <summary>
     ///
@@ -11,19 +10,18 @@
         /// <summary>
         ///
         /// </summary>
-        /// <param name="routingSettings"></param>
-        /// <typeparam name="T"></typeparam>
+        /// <param name="persistenceSettings"></param>
         /// <returns></returns>
-        public static PartitionAwareConfiguration Partition<T>(this RoutingSettings<T> routingSettings) where T : TransportDefinition
+        public static PartitionAwareConfiguration Partition(this PersistenceExtensions<CosmosDbPersistence> persistenceSettings)
         {
-            var settings = routingSettings.GetSettings();
+            var settings = persistenceSettings.GetSettings();
 
             if (settings.TryGet(out PartitionAwareConfiguration config))
             {
                 return config;
             }
 
-            config = new PartitionAwareConfiguration(routingSettings);
+            config = new PartitionAwareConfiguration(persistenceSettings);
             settings.Set(config);
 
             return config;

--- a/src/NServiceBus.Persistence.CosmosDB/Config/SettingsKeys.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/SettingsKeys.cs
@@ -5,11 +5,10 @@
         const string baseName = "CosmosDB.";
         public const string CosmosClient = baseName + nameof(CosmosClient);
         public const string ConnectionString =  nameof(baseName) + nameof(ConnectionString);
+        public const string DatabaseName = nameof(baseName) + nameof(DatabaseName);
 
         internal static class Sagas
         {
-            public const string DatabaseName =  nameof(baseName) + nameof(Sagas) + "." + nameof(DatabaseName);
-            public const string ContainerName =  nameof(baseName) + nameof(Sagas) + "." + nameof(ContainerName);
             public const string JsonSerializerSettings =  nameof(baseName) + nameof(Sagas) + "." + nameof(JsonSerializerSettings);
         }
     }

--- a/src/NServiceBus.Persistence.CosmosDB/CosmosDbPersistence.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/CosmosDbPersistence.cs
@@ -1,10 +1,7 @@
 ﻿namespace NServiceBus
 {
-    using System;
     using Features;
-    using Microsoft.Azure.Cosmos;
     using Persistence;
-    using Persistence.CosmosDB;
 
     /// <summary>
     /// CosmosDB Core API persistence
@@ -13,18 +10,6 @@
     {
         internal CosmosDbPersistence()
         {
-            Defaults(s =>
-            {
-                s.SetDefault(SettingsKeys.CosmosClient, (Func<CosmosClient>)(() =>
-                {
-                    if (!s.TryGet<string>(SettingsKeys.ConnectionString, out var connectionString))
-                    {
-                        throw new InvalidOperationException("Meaningful exception");
-                    }
-                    return new CosmosClient(connectionString);
-                }));
-            });
-
             Supports<StorageType.Sagas>(s => s.EnableFeatureByDefault<CosmosDbSagaPersistence>());
         }
     }

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/Config/SagaSettings.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/Config/SagaSettings.cs
@@ -13,25 +13,5 @@
         {
             this.settings = settings;
         }
-
-        /// <summary>
-        /// Database name to be used
-        /// </summary>
-        public void DatabaseName(string databaseName)
-        {
-            Guard.AgainstNullAndEmpty(nameof(databaseName), databaseName);
-
-            settings.Set(SettingsKeys.Sagas.DatabaseName, databaseName);
-        }
-
-        /// <summary>
-        /// Container name to be used
-        /// </summary>
-        public void ContainerName(string containerName)
-        {
-            Guard.AgainstNullAndEmpty(nameof(containerName), containerName);
-
-            settings.Set(SettingsKeys.Sagas.ContainerName, containerName);
-        }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosDbSagaPersistence.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosDbSagaPersistence.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Features
 {
-    using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
     using Newtonsoft.Json;
@@ -17,16 +16,14 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var clientFactory = context.Settings.Get<Func<CosmosClient>>(SettingsKeys.CosmosClient);
-            var databaseName = context.Settings.Get<string>(SettingsKeys.Sagas.DatabaseName);
+            var cosmosClient = context.Settings.Get<CosmosClient>(SettingsKeys.CosmosClient);
+            var databaseName = context.Settings.Get<string>(SettingsKeys.DatabaseName);
             var serializerSettings = context.Settings.Get<JsonSerializerSettings>(SettingsKeys.Sagas.JsonSerializerSettings);
             var sagaMetadataCollection = context.Settings.Get<SagaMetadataCollection>();
 
-            var cosmosClient = clientFactory();
-
             context.RegisterStartupTask(new InitializeContainers(cosmosClient, databaseName, sagaMetadataCollection));
 
-            context.Container.ConfigureComponent(builder => new SagaPersister(serializerSettings, cosmosClient, databaseName), DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent(builder => new SagaPersister(serializerSettings), DependencyLifecycle.SingleInstance);
         }
 
         class InitializeContainers : FeatureStartupTask

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
@@ -15,15 +15,14 @@
     {
         JsonSerializer serializer;
 
-        public SagaPersister(JsonSerializerSettings jsonSerializerSettings, CosmosClient cosmosClient, string databaseName)
+        public SagaPersister(JsonSerializerSettings jsonSerializerSettings)
         {
-            this.databaseName = databaseName;
-            this.cosmosClient = cosmosClient;
             serializer = JsonSerializer.Create(jsonSerializerSettings);
         }
 
         public async Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context)
         {
+            var storageSession = (StorageSession)session;
             var partitionKey = sagaData.Id.ToString();
             var jObject = JObject.FromObject(sagaData, serializer);
 
@@ -41,19 +40,14 @@
                 await jObject.WriteToAsync(jsonWriter).ConfigureAwait(false);
                 await jsonWriter.FlushAsync().ConfigureAwait(false);
 
-                // TODO use some kind of convention
-                var container = cosmosClient.GetContainer(databaseName, sagaData.GetType().Name);
-                var responseMessage = await container.CreateItemStreamAsync(stream, new PartitionKey(partitionKey)).ConfigureAwait(false);
-                if(responseMessage.StatusCode == HttpStatusCode.Conflict || responseMessage.StatusCode == HttpStatusCode.PreconditionFailed)
-                {
-                    throw new Exception("TODO");
-                }
-                context.Set("cosmosdb_etag", responseMessage.Headers.ETag);
+                var options = new TransactionalBatchItemRequestOptions();
+                storageSession.TransactionalBatch.CreateItemStream(stream, options);
             }
         }
 
         public async Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context)
         {
+            var storageSession = (StorageSession)session;
             var partitionKey = sagaData.Id.ToString();
             var jObject = JObject.FromObject(sagaData, serializer);
 
@@ -66,8 +60,12 @@
 
             // only update if we have the same version as in CosmosDB
             context.TryGet<string>("cosmosdb_etag", out var etag);
-            var options = new ItemRequestOptions { IfMatchEtag = etag };
+            var options = new TransactionalBatchItemRequestOptions
+            {
+                IfMatchEtag = etag,
+            };
 
+            // TODO: Do we need to keep the stream around?
             using (var stream = new MemoryStream())
             using (var streamWriter = new StreamWriter(stream))
             using (JsonWriter jsonWriter = new JsonTextWriter(streamWriter))
@@ -75,25 +73,17 @@
                 await jObject.WriteToAsync(jsonWriter).ConfigureAwait(false);
                 await jsonWriter.FlushAsync().ConfigureAwait(false);
 
-                // TODO use some kind of convention
-                var container = cosmosClient.GetContainer(databaseName, sagaData.GetType().Name);
-                // ReSharper disable once UnusedVariable
-                var responseMessage = await container.ReplaceItemStreamAsync(stream, partitionKey, new PartitionKey(partitionKey), options)
-                    .ConfigureAwait(false);
-
-                if (responseMessage.StatusCode == HttpStatusCode.Conflict || responseMessage.StatusCode == HttpStatusCode.PreconditionFailed)
-                {
-                    throw new Exception($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' was updated by another process or no longer exists.");
-                }
+                storageSession.TransactionalBatch.ReplaceItemStream(partitionKey, stream, options);
             }
         }
 
         public async Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context) where TSagaData : class, IContainSagaData
         {
+            var storageSession = (StorageSession)session;
             var partitionKey = sagaId.ToString();
 
-            // TODO use some kind of convention
-            var container = cosmosClient.GetContainer(databaseName, typeof(TSagaData).Name);
+            // reads need to go directly
+            var container = storageSession.Container;
             var responseMessage = await container.ReadItemStreamAsync(sagaId.ToString(), new PartitionKey(partitionKey)).ConfigureAwait(false);
 
             if(responseMessage.StatusCode == HttpStatusCode.NotFound || responseMessage.Content == null)
@@ -122,30 +112,23 @@
             return Get<TSagaData>(sagaId, session, context);
         }
 
-        public async Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context)
+        public Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context)
         {
             // TODO: currently we delete the item by ID. The idea is to use a document TTL to let CosmosDB remove the item.
             // TODO: this will allow developers to see that saga will be removed rather than not find it and wonder what happened.
+
+            var storageSession = (StorageSession)session;
 
             var partitionKey = sagaData.Id.ToString();
 
             // only delete if we have the same version as in CosmosDB
             context.TryGet<string>("cosmosdb_etag", out var etag);
-            var options = new ItemRequestOptions { IfMatchEtag = etag };
+            var options = new TransactionalBatchItemRequestOptions { IfMatchEtag = etag };
 
-            // TODO use some kind of convention
-            var container = cosmosClient.GetContainer(databaseName, sagaData.GetType().Name);
-            var responseMessage = await container.DeleteItemStreamAsync(sagaData.Id.ToString(), new PartitionKey(partitionKey), options)
-                .ConfigureAwait(false);
-
-            if(responseMessage.StatusCode == HttpStatusCode.Conflict || responseMessage.StatusCode == HttpStatusCode.PreconditionFailed)
-            {
-                throw new Exception($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' can't be completed because it was updated by another process.");
-            }
+            storageSession.TransactionalBatch.DeleteItem(partitionKey, options);
+            return Task.CompletedTask;
         }
 
         internal static readonly string SchemaVersion = "1.0.0";
-        CosmosClient cosmosClient;
-        string databaseName;
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSession.cs
@@ -1,0 +1,33 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+
+    class StorageSession : CompletableSynchronizedStorageSession
+    {
+        public Container Container { get; }
+        public TransactionalBatch TransactionalBatch { get; }
+
+        public StorageSession(Container container, TransactionalBatch transactionalBatch)
+        {
+            Container = container;
+            TransactionalBatch = transactionalBatch;
+        }
+
+        public void Dispose()
+        {
+            // for now
+        }
+
+        public async Task CompleteAsync()
+        {
+            using (var batchOutcomeResponse = await TransactionalBatch.ExecuteAsync().ConfigureAwait(false))
+            {
+                if (!batchOutcomeResponse.IsSuccessStatusCode)
+                {
+                    // TODO
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSession.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Persistence.CosmosDB
 {
+    using System;
+    using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
 
@@ -25,7 +27,14 @@
             {
                 if (!batchOutcomeResponse.IsSuccessStatusCode)
                 {
-                    // TODO
+                    foreach (var result in batchOutcomeResponse)
+                    {
+                        if (result.StatusCode == HttpStatusCode.Conflict || result.StatusCode == HttpStatusCode.PreconditionFailed)
+                        {
+                            // technically would could somehow map back to what we wrote if we store extra info in the session
+                            throw new Exception("Concurrent updates lead to write conflicts.");
+                        }
+                    }
                 }
             }
         }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSessionAdapter.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSessionAdapter.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Outbox;
+    using Transport;
+
+    class StorageSessionAdapter : ISynchronizedStorageAdapter
+    {
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context)
+        {
+            return emptyResult;
+        }
+
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context)
+        {
+            return emptyResult;
+        }
+
+        static readonly Task<CompletableSynchronizedStorageSession> emptyResult = Task.FromResult((CompletableSynchronizedStorageSession)null);
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSessionFactory.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSessionFactory.cs
@@ -1,0 +1,35 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Microsoft.Azure.Cosmos;
+    using Pipeline;
+    using Transport;
+
+    class StorageSessionFactory : ISynchronizedStorage
+    {
+        PartitionAwareConfiguration partitionAwareConfiguration;
+        CosmosClient cosmosClient;
+        string databaseName;
+
+        public StorageSessionFactory(string databaseName, CosmosClient cosmosClient, PartitionAwareConfiguration partitionAwareConfiguration)
+        {
+            this.databaseName = databaseName;
+            this.cosmosClient = cosmosClient;
+            this.partitionAwareConfiguration = partitionAwareConfiguration;
+        }
+
+        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag)
+        {
+            var incomingMessage = contextBag.Get<IncomingMessage>();
+            var logicalMessage = contextBag.Get<LogicalMessage>();
+
+            var partitionKey = partitionAwareConfiguration.MapMessageToPartition(incomingMessage.Headers, incomingMessage.MessageId, logicalMessage.MessageType, logicalMessage.Instance);
+            var containerName = partitionAwareConfiguration.MapMessageToContainer(logicalMessage.MessageType);
+            var container = cosmosClient.GetContainer(databaseName, containerName);
+            var transactionalBatch = container.CreateTransactionalBatch(partitionKey);
+
+            return Task.FromResult<CompletableSynchronizedStorageSession>(new StorageSession(container, transactionalBatch));
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -21,7 +21,7 @@
 
             if (partitionConfig is null)
             {
-                throw new Exception("No message partition mappings were found. Use transport.Partition() to configure mappings.");
+                throw new Exception("No message partition mappings were found. Use persistence.Partition() to configure mappings.");
             }
 
             context.Container.ConfigureComponent(() => new StorageSessionFactory(databaseName, client, partitionConfig), DependencyLifecycle.SingleInstance);

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System;
+    using Features;
+    using Microsoft.Azure.Cosmos;
+
+    class SynchronizedStorage : Feature
+    {
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            var clientFactory = context.Settings.Get<Func<CosmosClient>>(SettingsKeys.CosmosClient);
+            // TODO: Should not be a saga config
+            var databaseName = context.Settings.Get<string>(SettingsKeys.Sagas.DatabaseName);
+            // TODO: would throw if the extension is not called, make better
+            var partitionConfig = context.Settings.Get<PartitionAwareConfiguration>();
+
+            context.Container.ConfigureComponent(() => new StorageSessionFactory(databaseName, clientFactory(), partitionConfig), DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent<StorageSessionAdapter>(DependencyLifecycle.SingleInstance);
+        }
+    }
+}


### PR DESCRIPTION
Change PartitionAwareConfiguration to work with `PersistenceExtensions<CosmosDbPersistence>` for settings rather than `RoutingSettings<TransportDefinition>`.