### PR TITLE
Revert di support changes

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Config/CosmosDbPersistenceConfig.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/CosmosDbPersistenceConfig.cs
@@ -2,7 +2,6 @@
 {
     using Configuration.AdvancedExtensibility;
     using Microsoft.Azure.Cosmos;
-    using NServiceBus.Settings;
     using Persistence.CosmosDB;
 
     /// <summary>
@@ -55,16 +54,6 @@
         public static PersistenceExtensions<CosmosDbPersistence> DefaultContainer(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions, string containerName, string partitionKeyPath)
         {
             return DefaultContainer(persistenceExtensions, new ContainerInformation(containerName, new PartitionKeyPath(partitionKeyPath)));
-        }
-
-        /// <summary>
-        /// Registers the shared transactional batch for dependency injection.
-        /// </summary>
-        public static PersistenceExtensions<CosmosDbPersistence> RegisterSharedTransactionalBatchForDependencyInjection(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions)
-        {
-            persistenceExtensions.GetSettings().Set(SettingsKeys.RegisterSharedTransactionalBatch, true);
-
-            return persistenceExtensions;
         }
 
         /// <summary>

--- a/src/NServiceBus.Persistence.CosmosDB/Config/SettingsKeys.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/SettingsKeys.cs
@@ -5,6 +5,5 @@
         const string baseName = "CosmosDB.";
         public const string DatabaseName = nameof(baseName) + nameof(DatabaseName);
         public const string OutboxTimeToLiveInSeconds = nameof(baseName) + nameof(OutboxTimeToLiveInSeconds);
-        public const string RegisterSharedTransactionalBatch = nameof(baseName) + nameof(RegisterSharedTransactionalBatch);
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/ICosmosDBStorageSession.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/ICosmosDBStorageSession.cs
@@ -2,8 +2,14 @@
 {
     using Microsoft.Azure.Cosmos;
 
-    interface ICosmosDBStorageSession
+    /// <summary>
+    ///
+    /// </summary>
+    public interface ICosmosDBStorageSession
     {
+        /// <summary>
+        ///
+        /// </summary>
         TransactionalBatch Batch { get; }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorage.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorage.cs
@@ -27,11 +27,6 @@
             context.Container.ConfigureComponent(b=> new StorageSessionFactory(b.Build<ContainerHolderResolver>(), currentSharedTransactionalBatchHolder), DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent(b=> new StorageSessionAdapter(currentSharedTransactionalBatchHolder), DependencyLifecycle.SingleInstance);
 
-            if (context.Settings.TryGet(SettingsKeys.RegisterSharedTransactionalBatch, out bool _))
-            {
-                context.Container.ConfigureComponent(b => b.Build<ICosmosDBStorageSession>()?.Batch, DependencyLifecycle.InstancePerUnitOfWork);
-            }
-
             context.Pipeline.Register(new CurrentSharedTransactionalBatchBehavior(currentSharedTransactionalBatchHolder), "Manages the lifecycle of the current storage session.");
         }
     }

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_outbox_synchronized_session_via_container.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_outbox_synchronized_session_via_container.cs
@@ -3,7 +3,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Microsoft.Azure.Cosmos;
     using NUnit.Framework;
 
     [TestFixture]
@@ -37,11 +36,6 @@
                     config.RegisterComponents(c =>
                     {
                         c.ConfigureComponent<MyRepository>(DependencyLifecycle.InstancePerUnitOfWork);
-                        c.ConfigureComponent(b =>
-                        {
-                            var session = b.Build<ICosmosDBStorageSession>();
-                            return session?.Batch;
-                        }, DependencyLifecycle.InstancePerUnitOfWork);
                     });
                 });
             }
@@ -69,18 +63,18 @@
 
         public class MyRepository
         {
-            public MyRepository(TransactionalBatch batch, Context context)
+            public MyRepository(ICosmosDBStorageSession storageSession, Context context)
             {
-                this.batch = batch;
+                this.storageSession = storageSession;
                 this.context = context;
             }
 
             public void DoSomething()
             {
-                context.RepositoryHasBatch = batch != null;
+                context.RepositoryHasBatch = storageSession.Batch != null;
             }
 
-            TransactionalBatch batch;
+            ICosmosDBStorageSession storageSession;
             Context context;
         }
 

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_outbox_synchronized_session_via_container.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_outbox_synchronized_session_via_container.cs
@@ -34,10 +34,14 @@
                 EndpointSetup<DefaultServer>(config =>
                 {
                     config.EnableOutbox();
-                    config.UsePersistence<CosmosDbPersistence>().RegisterSharedTransactionalBatchForDependencyInjection();
                     config.RegisterComponents(c =>
                     {
                         c.ConfigureComponent<MyRepository>(DependencyLifecycle.InstancePerUnitOfWork);
+                        c.ConfigureComponent(b =>
+                        {
+                            var session = b.Build<ICosmosDBStorageSession>();
+                            return session?.Batch;
+                        }, DependencyLifecycle.InstancePerUnitOfWork);
                     });
                 });
             }

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
@@ -37,9 +37,16 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>((config, run) =>
+                EndpointSetup<DefaultServer>(config =>
                 {
-                    config.UsePersistence<CosmosDbPersistence>().RegisterSharedTransactionalBatchForDependencyInjection();
+                    config.RegisterComponents(c =>
+                    {
+                        c.ConfigureComponent(b =>
+                        {
+                            var session = b.Build<ICosmosDBStorageSession>();
+                            return session.Batch;
+                        }, DependencyLifecycle.InstancePerUnitOfWork);
+                    });
                 });
             }
 

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
@@ -3,7 +3,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Microsoft.Azure.Cosmos;
     using NUnit.Framework;
 
     [TestFixture]
@@ -18,19 +17,13 @@
                 .Run()
                 .ConfigureAwait(false);
 
-            Assert.IsNotNull(context.BatchInjectedToFirstHandler);
-            Assert.IsNotNull(context.BatchInjectedToSecondHandler);
-            Assert.IsNotNull(context.BatchInjectedToThirdHandler);
-            Assert.AreSame(context.BatchInjectedToFirstHandler, context.BatchInjectedToSecondHandler);
-            Assert.AreNotSame(context.BatchInjectedToFirstHandler, context.BatchInjectedToThirdHandler);
+            Assert.True(context.HandlerHasBatch);
         }
 
         public class Context : ScenarioContext
         {
             public bool Done { get; set; }
-            public TransactionalBatch BatchInjectedToFirstHandler { get; set; }
-            public TransactionalBatch BatchInjectedToSecondHandler { get; set; }
-            public TransactionalBatch BatchInjectedToThirdHandler { get; set; }
+            public bool HandlerHasBatch { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -40,9 +33,9 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class MyMessageHandler : IHandleMessages<MyMessage>
+            public class MyHandler : IHandleMessages<MyMessage>
             {
-                public MyMessageHandler(ICosmosDBStorageSession session, Context context)
+                public MyHandler(ICosmosDBStorageSession session, Context context)
                 {
                     this.session = session;
                     this.context = context;
@@ -50,49 +43,9 @@
 
                 public Task Handle(MyMessage message, IMessageHandlerContext handlerContext)
                 {
-                    context.BatchInjectedToFirstHandler = session.Batch;
-                    return handlerContext.SendLocal(new MyFollowUpMessage
-                    {
-                        Property = message.Property
-                    });
-                }
-
-                Context context;
-                ICosmosDBStorageSession session;
-            }
-
-            public class MyOtherMessageHandler : IHandleMessages<MyMessage>
-            {
-                public MyOtherMessageHandler(ICosmosDBStorageSession session, Context context)
-                {
-                    this.session = session;
-                    this.context = context;
-                }
-
-
-                public Task Handle(MyMessage message, IMessageHandlerContext handlerContext)
-                {
-                    context.BatchInjectedToSecondHandler = session.Batch;
-                    return Task.CompletedTask;
-                }
-
-                Context context;
-                ICosmosDBStorageSession session;
-            }
-
-            public class MyFollowUpMessageHandler : IHandleMessages<MyFollowUpMessage>
-            {
-                public MyFollowUpMessageHandler(ICosmosDBStorageSession session, Context context)
-                {
-                    this.session = session;
-                    this.context = context;
-                }
-
-
-                public Task Handle(MyFollowUpMessage message, IMessageHandlerContext handlerContext)
-                {
-                    context.BatchInjectedToThirdHandler = session.Batch;
                     context.Done = true;
+                    context.HandlerHasBatch = session.Batch != null;
+
                     return Task.CompletedTask;
                 }
 
@@ -102,11 +55,6 @@
         }
 
         public class MyMessage : IMessage
-        {
-            public string Property { get; set; }
-        }
-
-        public class MyFollowUpMessage : IMessage
         {
             public string Property { get; set; }
         }

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
@@ -37,30 +37,20 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(config =>
-                {
-                    config.RegisterComponents(c =>
-                    {
-                        c.ConfigureComponent(b =>
-                        {
-                            var session = b.Build<ICosmosDBStorageSession>();
-                            return session?.Batch;
-                        }, DependencyLifecycle.InstancePerUnitOfWork);
-                    });
-                });
+                EndpointSetup<DefaultServer>();
             }
 
             public class MyMessageHandler : IHandleMessages<MyMessage>
             {
-                public MyMessageHandler(TransactionalBatch batch, Context context)
+                public MyMessageHandler(ICosmosDBStorageSession session, Context context)
                 {
-                    this.batch = batch;
+                    this.session = session;
                     this.context = context;
                 }
 
                 public Task Handle(MyMessage message, IMessageHandlerContext handlerContext)
                 {
-                    context.BatchInjectedToFirstHandler = batch;
+                    context.BatchInjectedToFirstHandler = session.Batch;
                     return handlerContext.SendLocal(new MyFollowUpMessage
                     {
                         Property = message.Property
@@ -68,46 +58,46 @@
                 }
 
                 Context context;
-                TransactionalBatch batch;
+                ICosmosDBStorageSession session;
             }
 
             public class MyOtherMessageHandler : IHandleMessages<MyMessage>
             {
-                public MyOtherMessageHandler(TransactionalBatch batch, Context context)
+                public MyOtherMessageHandler(ICosmosDBStorageSession session, Context context)
                 {
-                    this.batch = batch;
+                    this.session = session;
                     this.context = context;
                 }
 
 
                 public Task Handle(MyMessage message, IMessageHandlerContext handlerContext)
                 {
-                    context.BatchInjectedToSecondHandler = batch;
+                    context.BatchInjectedToSecondHandler = session.Batch;
                     return Task.CompletedTask;
                 }
 
                 Context context;
-                TransactionalBatch batch;
+                ICosmosDBStorageSession session;
             }
 
             public class MyFollowUpMessageHandler : IHandleMessages<MyFollowUpMessage>
             {
-                public MyFollowUpMessageHandler(TransactionalBatch batch, Context context)
+                public MyFollowUpMessageHandler(ICosmosDBStorageSession session, Context context)
                 {
-                    this.batch = batch;
+                    this.session = session;
                     this.context = context;
                 }
 
 
                 public Task Handle(MyFollowUpMessage message, IMessageHandlerContext handlerContext)
                 {
-                    context.BatchInjectedToThirdHandler = batch;
+                    context.BatchInjectedToThirdHandler = session.Batch;
                     context.Done = true;
                     return Task.CompletedTask;
                 }
 
                 Context context;
-                TransactionalBatch batch;
+                ICosmosDBStorageSession session;
             }
         }
 

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
@@ -37,30 +37,20 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(config =>
-                {
-                    config.RegisterComponents(c =>
-                    {
-                        c.ConfigureComponent(b =>
-                        {
-                            var session = b.Build<ICosmosDBStorageSession>();
-                            return session.Batch;
-                        }, DependencyLifecycle.InstancePerUnitOfWork);
-                    });
-                });
+                EndpointSetup<DefaultServer>();
             }
 
             public class MyMessageHandler : IHandleMessages<MyMessage>
             {
-                public MyMessageHandler(TransactionalBatch batch, Context context)
+                public MyMessageHandler(ICosmosDBStorageSession storageSession, Context context)
                 {
-                    this.batch = batch;
+                    this.storageSession = storageSession;
                     this.context = context;
                 }
 
                 public Task Handle(MyMessage message, IMessageHandlerContext handlerContext)
                 {
-                    context.BatchInjectedToFirstHandler = batch;
+                    context.BatchInjectedToFirstHandler = storageSession.Batch;
                     return handlerContext.SendLocal(new MyFollowUpMessage
                     {
                         Property = message.Property
@@ -68,7 +58,7 @@
                 }
 
                 Context context;
-                TransactionalBatch batch;
+                ICosmosDBStorageSession storageSession;
             }
 
             public class MyOtherMessageHandler : IHandleMessages<MyMessage>


### PR DESCRIPTION
A) compliant with other persisted approaches
B) Registering an SDK type directly is not a good idea because customers can already have it registered
C) In order to address the above you had to introduce another setting method
D) It violates the design principles we have for DI support

![image](https://user-images.githubusercontent.com/174258/93570868-f4281e00-f993-11ea-9338-c10ff7ebf4fd.png)

I changed the tests to use the storage session directly. I think that was the misleading part that caused us down the path of wanting to remove it
