### PR TITLE
Fix saga persister get problem

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
@@ -50,12 +50,12 @@
 
                 var sagaNotFound = responseMessage.StatusCode == HttpStatusCode.NotFound || sagaStream == null;
 
-                if (sagaNotFound && !migrationModeEnabled)
+                if (sagaNotFound && isGeneratedSagaId)
                 {
                     return default;
                 }
 
-                if (sagaNotFound && migrationModeEnabled && !isGeneratedSagaId)
+                if (sagaNotFound && migrationModeEnabled)
                 {
                     var query = $@"SELECT TOP 1 * FROM c WHERE c[""{MetadataExtensions.MetadataKey}""][""{MetadataExtensions.SagaDataContainerMigratedSagaIdMetadataKey}""] = '{sagaId}'";
                     var queryDefinition = new QueryDefinition(query);
@@ -81,6 +81,11 @@
                             return sagaData;
                         }
                     }
+                }
+
+                if (sagaStream == null)
+                {
+                    return default;
                 }
 
                 using(sagaStream)


### PR DESCRIPTION
SagaPersister get logic cannot handle cases when messages are still in flight but no saga data has been created or imported yet.

I detected this case while sending thousands of messages to the server and then migrate the server while there where still messages in the queue that would start a saga.