### PR TITLE
Shorten tool package name

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageId>NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter</PackageId>
+    <PackageId>NServiceBus.Export.AspSagas</PackageId>
     <Description>Tool to extract saga data from NServiceBus.Persistence.AzureStorage for import into NServiceBus.Persistence.CosmosDB</Description>
     <ToolCommandName>export-aspsagas</ToolCommandName>
     <PackAsTool>True</PackAsTool>


### PR DESCRIPTION
The longer package name combined with the path .NET Tool is creating is easily exceeding 260 characters even when installed as a local tool.
To avoid problems, it's better to shorten the name.