### PR TITLE
Expose Container, PartitionKey, PartitionKeyPath on the storage session

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/When_using_outbox_synchronized_session_via_container_partial.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/When_using_outbox_synchronized_session_via_container_partial.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using Microsoft.Azure.Cosmos;
+    using NUnit.Framework;
+
+    public partial class When_using_outbox_synchronized_session_via_container
+    {
+        partial void AssertPartitionPart(Context scenarioContext)
+        {
+            string partitionKeyPath = scenarioContext.PartitionKeyPath;
+            Assert.AreEqual(SetupFixture.PartitionPathKey, partitionKeyPath);
+            Assert.AreEqual(new PartitionKey(scenarioContext.TestRunId.ToString()), scenarioContext.PartitionKey);
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/When_using_outbox_synchronized_session_via_container_partial.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/When_using_outbox_synchronized_session_via_container_partial.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using Microsoft.Azure.Cosmos;
+    using NUnit.Framework;
+
+    public partial class When_using_outbox_synchronized_session_via_container
+    {
+        partial void AssertPartitionPart(Context scenarioContext)
+        {
+            string partitionKeyPath = scenarioContext.PartitionKeyPath;
+            Assert.AreEqual(SetupFixture.PartitionPathKey, partitionKeyPath);
+            Assert.AreEqual(new PartitionKey(scenarioContext.TestRunId.ToString()), scenarioContext.PartitionKey);
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -28,6 +28,9 @@ namespace NServiceBus
     public interface ICosmosDBStorageSession
     {
         Microsoft.Azure.Cosmos.TransactionalBatch Batch { get; }
+        Microsoft.Azure.Cosmos.Container Container { get; }
+        Microsoft.Azure.Cosmos.PartitionKey PartitionKey { get; }
+        NServiceBus.PartitionKeyPath PartitionKeyPath { get; }
     }
     public interface IProvideCosmosClient
     {
@@ -36,6 +39,7 @@ namespace NServiceBus
     public struct PartitionKeyPath
     {
         public PartitionKeyPath(string partitionKeyPath) { }
+        public override string ToString() { }
         public static string op_Implicit(NServiceBus.PartitionKeyPath path) { }
     }
     public class static SynchronizedStorageSessionExtensions
@@ -62,5 +66,8 @@ namespace NServiceBus.Testing
     public class TestableCosmosSynchronizedStorageSession : NServiceBus.Persistence.SynchronizedStorageSession
     {
         public TestableCosmosSynchronizedStorageSession(Microsoft.Azure.Cosmos.PartitionKey partitionKey) { }
+        public Microsoft.Azure.Cosmos.Container Container { get; set; }
+        public NServiceBus.PartitionKeyPath PartitionKeyPath { get; set; }
+        public Microsoft.Azure.Cosmos.TransactionalBatch TransactionalBatch { get; set; }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/SynchronizedStorage/TestableCosmosSynchronizedStorageSessionTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/SynchronizedStorage/TestableCosmosSynchronizedStorageSessionTests.cs
@@ -1,0 +1,109 @@
+﻿namespace NServiceBus.Persistence.CosmosDB.Tests
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using NUnit.Framework;
+    using Testing;
+
+    [TestFixture]
+    public class TestableCosmosSynchronizedStorageSessionTests
+    {
+        [Test]
+        public async Task CanBeUsed()
+        {
+            var transactionalBatch = new FakeTransactionalBatch();
+
+            var testableSession = new TestableCosmosSynchronizedStorageSession(new PartitionKey("mypartitionkey"))
+            {
+                TransactionalBatch = transactionalBatch
+            };
+            var handlerContext = new TestableInvokeHandlerContext
+            {
+                SynchronizedStorageSession = testableSession
+            };
+
+            var handler = new HandlerUsingSynchronizedStorageSessionExtension();
+            await handler.Handle(new MyMessage(), handlerContext);
+
+            Assert.IsNotEmpty(transactionalBatch.CreatedItems.OfType<MyItem>());
+        }
+
+        class FakeTransactionalBatch : TransactionalBatch
+        {
+            public List<object> CreatedItems { get; } = new List<object>();
+
+            public override TransactionalBatch CreateItem<T>(T item, TransactionalBatchItemRequestOptions requestOptions = null)
+            {
+                CreatedItems.Add(item);
+                return this;
+            }
+
+            public override TransactionalBatch CreateItemStream(Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override TransactionalBatch ReadItem(string id, TransactionalBatchItemRequestOptions requestOptions = null)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override TransactionalBatch UpsertItem<T>(T item, TransactionalBatchItemRequestOptions requestOptions = null)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override TransactionalBatch UpsertItemStream(Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override TransactionalBatch ReplaceItem<T>(string id, T item, TransactionalBatchItemRequestOptions requestOptions = null)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override TransactionalBatch ReplaceItemStream(string id, Stream streamPayload, TransactionalBatchItemRequestOptions requestOptions = null)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override TransactionalBatch DeleteItem(string id, TransactionalBatchItemRequestOptions requestOptions = null)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override Task<TransactionalBatchResponse> ExecuteAsync(CancellationToken cancellationToken = new CancellationToken())
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public override Task<TransactionalBatchResponse> ExecuteAsync(TransactionalBatchRequestOptions requestOptions, CancellationToken cancellationToken = new CancellationToken())
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        class HandlerUsingSynchronizedStorageSessionExtension : IHandleMessages<MyMessage>
+        {
+            public Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                var batch = context.SynchronizedStorageSession.GetSharedTransactionalBatch();
+                var myItem = new MyItem();
+                batch.CreateItem(myItem);
+                return Task.CompletedTask;
+            }
+        }
+
+        class MyItem
+        {
+            public string Id { get; set; }
+        }
+
+        class MyMessage {}
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB/Config/PartitionKeyPath.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/PartitionKeyPath.cs
@@ -22,5 +22,11 @@
         {
             return path.partitionKeyPath;
         }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return partitionKeyPath;
+        }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/ICosmosDBStorageSession.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/ICosmosDBStorageSession.cs
@@ -8,7 +8,22 @@
     public interface ICosmosDBStorageSession
     {
         /// <summary>
-        ///
+        /// The partition key
+        /// </summary>
+        PartitionKey PartitionKey { get; }
+
+        /// <summary>
+        /// The partition key path
+        /// </summary>
+        PartitionKeyPath PartitionKeyPath { get; }
+
+        /// <summary>
+        /// The container
+        /// </summary>
+        Microsoft.Azure.Cosmos.Container Container { get; }
+
+        /// <summary>
+        /// The transactional batch
         /// </summary>
         TransactionalBatch Batch { get; }
     }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/IWorkWithSharedTransactionalBatch.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/IWorkWithSharedTransactionalBatch.cs
@@ -1,11 +1,14 @@
 ﻿namespace NServiceBus.Persistence.CosmosDB
 {
     using Extensibility;
+    using Microsoft.Azure.Cosmos;
 
     // Required for testing
-    internal interface IWorkWithSharedTransactionalBatch
+    interface IWorkWithSharedTransactionalBatch
     {
         void AddOperation(Operation operation);
         ContextBag CurrentContextBag { get; set; }
+        Container Container { get; }
+        PartitionKeyPath PartitionKeyPath { get; }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SharedTransactionalBatch.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SharedTransactionalBatch.cs
@@ -11,8 +11,13 @@
         public SharedTransactionalBatch(IWorkWithSharedTransactionalBatch operationsHolder, PartitionKey partitionKey)
         {
             this.operationsHolder = operationsHolder;
-            this.partitionKey = partitionKey;
+            PartitionKey = partitionKey;
         }
+
+        public PartitionKey PartitionKey { get; }
+
+        public Container Container => operationsHolder.Container;
+        public PartitionKeyPath PartitionKeyPath => operationsHolder.PartitionKeyPath;
 
         public TransactionalBatch Batch => this;
 
@@ -20,7 +25,7 @@
         {
             Guard.AgainstNull(nameof(item), item);
 
-            operationsHolder.AddOperation(new CreateItemOperation<T>(item, requestOptions, partitionKey));
+            operationsHolder.AddOperation(new CreateItemOperation<T>(item, requestOptions, PartitionKey));
             return this;
         }
 
@@ -28,7 +33,7 @@
         {
             Guard.AgainstNull(nameof(streamPayload), streamPayload);
 
-            operationsHolder.AddOperation(new CreateItemStreamOperation(streamPayload, requestOptions, partitionKey));
+            operationsHolder.AddOperation(new CreateItemStreamOperation(streamPayload, requestOptions, PartitionKey));
             return this;
         }
 
@@ -36,7 +41,7 @@
         {
             Guard.AgainstNullAndEmpty(nameof(id), id);
 
-            operationsHolder.AddOperation(new ReadItemOperation(id, requestOptions, partitionKey));
+            operationsHolder.AddOperation(new ReadItemOperation(id, requestOptions, PartitionKey));
             return this;
         }
 
@@ -44,7 +49,7 @@
         {
             Guard.AgainstNull(nameof(item), item);
 
-            operationsHolder.AddOperation(new UpsertItemOperation<T>(item, requestOptions, partitionKey));
+            operationsHolder.AddOperation(new UpsertItemOperation<T>(item, requestOptions, PartitionKey));
             return this;
         }
 
@@ -52,7 +57,7 @@
         {
             Guard.AgainstNull(nameof(streamPayload), streamPayload);
 
-            operationsHolder.AddOperation(new UpsertItemStreamOperation(streamPayload, requestOptions, partitionKey));
+            operationsHolder.AddOperation(new UpsertItemStreamOperation(streamPayload, requestOptions, PartitionKey));
             return this;
         }
 
@@ -61,7 +66,7 @@
             Guard.AgainstNullAndEmpty(nameof(id), id);
             Guard.AgainstNull(nameof(item), item);
 
-            operationsHolder.AddOperation(new ReplaceItemOperation<T>(id, item, requestOptions, partitionKey));
+            operationsHolder.AddOperation(new ReplaceItemOperation<T>(id, item, requestOptions, PartitionKey));
             return this;
         }
 
@@ -70,7 +75,7 @@
             Guard.AgainstNullAndEmpty(nameof(id), id);
             Guard.AgainstNull(nameof(streamPayload), streamPayload);
 
-            operationsHolder.AddOperation(new ReplaceItemStreamOperation(id, streamPayload, requestOptions, partitionKey));
+            operationsHolder.AddOperation(new ReplaceItemStreamOperation(id, streamPayload, requestOptions, PartitionKey));
             return this;
         }
 
@@ -78,7 +83,7 @@
         {
             Guard.AgainstNullAndEmpty(nameof(id), id);
 
-            operationsHolder.AddOperation(new DeleteItemOperation(id, requestOptions, partitionKey));
+            operationsHolder.AddOperation(new DeleteItemOperation(id, requestOptions, PartitionKey));
             return this;
         }
 
@@ -93,6 +98,5 @@
         }
 
         readonly IWorkWithSharedTransactionalBatch operationsHolder;
-        readonly PartitionKey partitionKey;
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSession.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/StorageSession.cs
@@ -74,7 +74,8 @@
 
         readonly bool commitOnComplete;
         public ContextBag CurrentContextBag { get; set; }
-
+        public Container Container => ContainerHolder.Container;
+        public PartitionKeyPath PartitionKeyPath => ContainerHolder.PartitionKeyPath;
         public ContainerHolder ContainerHolder { get; set; }
 
         readonly Dictionary<PartitionKey, Dictionary<int, Operation>> operations = new Dictionary<PartitionKey, Dictionary<int, Operation>>();

--- a/src/NServiceBus.Persistence.CosmosDB/Testing/TestableCosmosSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Testing/TestableCosmosSynchronizedStorageSession.cs
@@ -22,9 +22,28 @@
 
         ContextBag IWorkWithSharedTransactionalBatch.CurrentContextBag { get; set; }
 
+        /// <summary>
+        ///
+        /// </summary>
+        public Container Container { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public PartitionKeyPath PartitionKeyPath { get; set; }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public TransactionalBatch TransactionalBatch { get; set; }
+
         void IWorkWithSharedTransactionalBatch.AddOperation(Operation operation)
         {
-            //Do nothing (for now?)
+            if (TransactionalBatch == null)
+            {
+                return;
+            }
+            operation.Apply(TransactionalBatch, PartitionKeyPath);
         }
     }
 }


### PR DESCRIPTION
Based on customer feedback.

There are basically two options:

- Make container holder public
- Provide all the necessary information on the storage session

I opted for the latter because I think then the storage session is sufficiently self-contained so that any more complex workflow can fully rely on DI patterns to create advanced things like identity map