### PR TITLE
Remove DB from internal types

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter.AcceptanceTests/MigrationEndToEnd.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter.AcceptanceTests/MigrationEndToEnd.cs
@@ -71,7 +71,7 @@
                     var routing = ec.ConfigureTransport().Routing();
                     routing.RouteToEndpoint(typeof(CompleteSagaRequest), typeof(SomeOtherEndpoint));
 
-                    var persistence = ec.UsePersistence<CosmosDbPersistence>();
+                    var persistence = ec.UsePersistence<CosmosPersistence>();
                     persistence.CosmosClient(CosmosClient);
                     persistence.DatabaseName(DatabaseName);
                     persistence.DefaultContainer(ContainerName, PartitionPathKey);
@@ -89,7 +89,7 @@
 
         string DetermineAndVerifyExport(Context testContext)
         {
-            var newId = CosmosDBSagaIdGenerator.Generate(typeof(MigratingEndpoint.MigratingSagaData).FullName, nameof(MigratingEndpoint.MigratingSagaData.MyId), testContext.MyId.ToString());
+            var newId = CosmosSagaIdGenerator.Generate(typeof(MigratingEndpoint.MigratingSagaData).FullName, nameof(MigratingEndpoint.MigratingSagaData.MyId), testContext.MyId.ToString());
 
             var filePath = Path.Combine(workingDir, nameof(MigratingEndpoint.MigratingSagaData), $"{newId}.json");
 

--- a/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/Exporter.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/Exporter.cs
@@ -115,7 +115,7 @@
             var propertyName = match.Groups["PropertyName"].Value;
             var propertyValue = match.Groups["PropertyValue"].Value;
 
-            var newSagaId = CosmosDBSagaIdGenerator.Generate(sagaDataTypeFullName, propertyName, propertyValue);
+            var newSagaId = CosmosSagaIdGenerator.Generate(sagaDataTypeFullName, propertyName, propertyValue);
             var oldSagaId = entity["Id"].GuidValue;
 
             entity.Remove("NServiceBus_2ndIndexKey");

--- a/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter.csproj
@@ -21,7 +21,7 @@
     <Compile Include="..\NServiceBus.Persistence.CosmosDB\MetadataExtensions.cs" Link="MetadataExtensions.Common.cs" />
     <Compile Include="..\NServiceBus.Persistence.CosmosDB\Saga\MetadataExtensions.cs" Link="MetadataExtensions.Sagas.cs" />
     <Compile Include="..\NServiceBus.Persistence.CosmosDB\Saga\SagaSchemaVersion.cs" Link="SagaSchemaVersion.cs" />
-    <Compile Include="..\NServiceBus.Persistence.CosmosDB\Saga\CosmosDBSagaIdGenerator.cs" Link="CosmosDBSagaIdGenerator.cs" />
+    <Compile Include="..\NServiceBus.Persistence.CosmosDB\Saga\CosmosSagaIdGenerator.cs" Link="CosmosSagaIdGenerator.cs" />
     <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
   </ItemGroup>
 

--- a/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/ConfigureEndpointCosmosDBPersistence.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/ConfigureEndpointCosmosDBPersistence.cs
@@ -18,7 +18,7 @@ public class ConfigureEndpointCosmosDBPersistence : IConfigureEndpointTestExecut
             return Task.FromResult(0);
         }
 
-        var persistence = configuration.UsePersistence<CosmosDbPersistence>();
+        var persistence = configuration.UsePersistence<CosmosPersistence>();
         persistence.DisableContainerCreation();
         persistence.CosmosClient(SetupFixture.CosmosDbClient);
         persistence.DatabaseName(SetupFixture.DatabaseName);

--- a/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/SetupFixture.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/SetupFixture.cs
@@ -26,7 +26,7 @@
 
             CosmosDbClient = builder.Build();
 
-            var installer = new CosmosDBPersistenceInstaller(new CosmosClientProvidedByConfiguration
+            var installer = new Installer(new CosmosClientProvidedByConfiguration
             {
                 Client = CosmosDbClient
             }, new InstallerSettings

--- a/src/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests/ConfigureEndpointCosmosDBPersistence.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests/ConfigureEndpointCosmosDBPersistence.cs
@@ -13,7 +13,7 @@ public class ConfigureEndpointCosmosDBPersistence : IConfigureEndpointTestExecut
             return Task.FromResult(0);
         }
 
-        var persistence = configuration.UsePersistence<CosmosDbPersistence>();
+        var persistence = configuration.UsePersistence<CosmosPersistence>();
         persistence.DisableContainerCreation();
         persistence.CosmosClient(SetupFixture.CosmosDbClient);
         persistence.DatabaseName(SetupFixture.DatabaseName);

--- a/src/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests/SetupFixture.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests/SetupFixture.cs
@@ -26,7 +26,7 @@
 
             CosmosDbClient = builder.Build();
 
-            var installer = new CosmosDBPersistenceInstaller(new CosmosClientProvidedByConfiguration
+            var installer = new Installer(new CosmosClientProvidedByConfiguration
             {
                 Client = CosmosDbClient
             }, new InstallerSettings

--- a/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -39,7 +39,7 @@
 
             var serializer = new JsonSerializer
             {
-                ContractResolver = new CosmosDBContractResolver()
+                ContractResolver = new UpperCaseIdIntoLowerCaseIdContractResolver()
             };
 
             var partitionKeyPath = new PartitionKeyPath(SetupFixture.PartitionPathKey);

--- a/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/SetupFixture.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/SetupFixture.cs
@@ -26,7 +26,7 @@
 
             CosmosDbClient = builder.Build();
 
-            var installer = new CosmosDBPersistenceInstaller(new CosmosClientProvidedByConfiguration
+            var installer = new Installer(new CosmosClientProvidedByConfiguration
             {
                 Client = CosmosDbClient
             }, new InstallerSettings

--- a/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/ConfigureEndpointCosmosDBPersistence.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/ConfigureEndpointCosmosDBPersistence.cs
@@ -17,7 +17,7 @@ public class ConfigureEndpointCosmosDBPersistence : IConfigureEndpointTestExecut
             return Task.FromResult(0);
         }
 
-        var persistence = configuration.UsePersistence<CosmosDbPersistence>();
+        var persistence = configuration.UsePersistence<CosmosPersistence>();
         persistence.DisableContainerCreation();
         persistence.CosmosClient(SetupFixture.CosmosDbClient);
         persistence.DatabaseName(SetupFixture.DatabaseName);

--- a/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/SetupFixture.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/SetupFixture.cs
@@ -26,7 +26,7 @@
 
             CosmosDbClient = builder.Build();
 
-            var installer = new CosmosDBPersistenceInstaller(new CosmosClientProvidedByConfiguration
+            var installer = new Installer(new CosmosClientProvidedByConfiguration
             {
                 Client = CosmosDbClient
             }, new InstallerSettings

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/ApiApprovals.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/ApiApprovals.cs
@@ -11,7 +11,7 @@
         [Test]
         public void Approve()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(CosmosDbPersistence).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(CosmosPersistence).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
             Approver.Verify(publicApi);
         }
     }

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -12,20 +12,20 @@ namespace NServiceBus
         public string ContainerName { get; }
         public NServiceBus.PartitionKeyPath PartitionKeyPath { get; }
     }
-    public class static CosmosDBOutboxSettingsExtensions
+    public class static CosmosOutboxSettingsExtensions
     {
         public static void TimeToKeepOutboxDeduplicationData(this NServiceBus.Outbox.OutboxSettings outboxSettings, System.TimeSpan timeToKeepOutboxDeduplicationData) { }
     }
-    public class CosmosDbPersistence : NServiceBus.Persistence.PersistenceDefinition { }
-    public class static CosmosDbPersistenceConfig
+    public class CosmosPersistence : NServiceBus.Persistence.PersistenceDefinition { }
+    public class static CosmosPersistenceConfig
     {
-        public static NServiceBus.PersistenceExtensions<NServiceBus.CosmosDbPersistence> CosmosClient(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosDbPersistence> persistenceExtensions, Microsoft.Azure.Cosmos.CosmosClient cosmosClient) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.CosmosDbPersistence> DatabaseName(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosDbPersistence> persistenceExtensions, string databaseName) { }
-        public static NServiceBus.PersistenceExtensions<NServiceBus.CosmosDbPersistence> DefaultContainer(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosDbPersistence> persistenceExtensions, string containerName, string partitionKeyPath) { }
-        public static void DisableContainerCreation(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosDbPersistence> persistenceExtensions) { }
-        public static void EnableMigrationMode(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosDbPersistence> persistenceExtensions) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.CosmosPersistence> CosmosClient(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosPersistence> persistenceExtensions, Microsoft.Azure.Cosmos.CosmosClient cosmosClient) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.CosmosPersistence> DatabaseName(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosPersistence> persistenceExtensions, string databaseName) { }
+        public static NServiceBus.PersistenceExtensions<NServiceBus.CosmosPersistence> DefaultContainer(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosPersistence> persistenceExtensions, string containerName, string partitionKeyPath) { }
+        public static void DisableContainerCreation(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosPersistence> persistenceExtensions) { }
+        public static void EnableMigrationMode(this NServiceBus.PersistenceExtensions<NServiceBus.CosmosPersistence> persistenceExtensions) { }
     }
-    public interface ICosmosDBStorageSession
+    public interface ICosmosStorageSession
     {
         Microsoft.Azure.Cosmos.TransactionalBatch Batch { get; }
         Microsoft.Azure.Cosmos.Container Container { get; }

--- a/src/NServiceBus.Persistence.CosmosDB/Config/CosmosPersistenceConfig.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/CosmosPersistenceConfig.cs
@@ -5,15 +5,15 @@
     using Persistence.CosmosDB;
 
     /// <summary>
-    /// Configuration extensions for CosmosDB Core API Persistence
+    /// Configuration extensions for Cosmos DB Core API Persistence
     /// </summary>
-    public static class CosmosDbPersistenceConfig
+    public static class CosmosPersistenceConfig
     {
         /// <summary>
         /// Override the default CosmosClient creation by providing a pre-configured CosmosClient
         /// </summary>
         /// <remarks>The lifetime of the provided client is assumed to be controlled by the caller of this method and thus the client will not be disposed.</remarks>
-        public static PersistenceExtensions<CosmosDbPersistence> CosmosClient(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions, CosmosClient cosmosClient)
+        public static PersistenceExtensions<CosmosPersistence> CosmosClient(this PersistenceExtensions<CosmosPersistence> persistenceExtensions, CosmosClient cosmosClient)
         {
             Guard.AgainstNull(nameof(persistenceExtensions), persistenceExtensions);
             Guard.AgainstNull(nameof(cosmosClient), cosmosClient);
@@ -25,7 +25,7 @@
         /// <summary>
         /// Sets the database name
         /// </summary>
-        public static PersistenceExtensions<CosmosDbPersistence> DatabaseName(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions, string databaseName)
+        public static PersistenceExtensions<CosmosPersistence> DatabaseName(this PersistenceExtensions<CosmosPersistence> persistenceExtensions, string databaseName)
         {
             Guard.AgainstNullAndEmpty(nameof(databaseName), databaseName);
 
@@ -38,7 +38,7 @@
         /// Sets the default container name and the partition key path that will be used.
         /// </summary>
         /// <remarks>When the default container is not set the container information needs to be provided as part of the message handling pipeline.</remarks>
-        public static PersistenceExtensions<CosmosDbPersistence> DefaultContainer(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions, string containerName, string partitionKeyPath)
+        public static PersistenceExtensions<CosmosPersistence> DefaultContainer(this PersistenceExtensions<CosmosPersistence> persistenceExtensions, string containerName, string partitionKeyPath)
         {
             Guard.AgainstNull(nameof(persistenceExtensions), persistenceExtensions);
 
@@ -50,7 +50,7 @@
         /// <summary>
         /// Disables the container creation.
         /// </summary>
-        public static void DisableContainerCreation(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions)
+        public static void DisableContainerCreation(this PersistenceExtensions<CosmosPersistence> persistenceExtensions)
         {
             Guard.AgainstNull(nameof(persistenceExtensions), persistenceExtensions);
 
@@ -61,7 +61,7 @@
         /// <summary>
         /// Enable support for sagas migrated from other persistence technologies by querying the saga from storage using a migrated saga id.
         /// </summary>
-        public static void EnableMigrationMode(this PersistenceExtensions<CosmosDbPersistence> persistenceExtensions)
+        public static void EnableMigrationMode(this PersistenceExtensions<CosmosPersistence> persistenceExtensions)
         {
             Guard.AgainstNull(nameof(persistenceExtensions), persistenceExtensions);
 

--- a/src/NServiceBus.Persistence.CosmosDB/CosmosPersistence.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/CosmosPersistence.cs
@@ -7,9 +7,9 @@
     /// <summary>
     /// CosmosDB Core API persistence
     /// </summary>
-    public class CosmosDbPersistence : PersistenceDefinition
+    public class CosmosPersistence : PersistenceDefinition
     {
-        internal CosmosDbPersistence()
+        internal CosmosPersistence()
         {
             Defaults(s =>
             {

--- a/src/NServiceBus.Persistence.CosmosDB/Installer.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Installer.cs
@@ -6,9 +6,9 @@
     using Logging;
     using Microsoft.Azure.Cosmos;
 
-    class CosmosDBPersistenceInstaller : INeedToInstallSomething
+    class Installer : INeedToInstallSomething
     {
-        public CosmosDBPersistenceInstaller(IProvideCosmosClient clientProvider, InstallerSettings settings)
+        public Installer(IProvideCosmosClient clientProvider, InstallerSettings settings)
         {
             installerSettings = settings;
             this.clientProvider = clientProvider;
@@ -46,7 +46,7 @@
         }
 
         InstallerSettings installerSettings;
-        static ILog log = LogManager.GetLogger<CosmosDBPersistenceInstaller>();
+        static ILog log = LogManager.GetLogger<Installer>();
         readonly IProvideCosmosClient clientProvider;
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/CosmosOutboxSettingsExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/CosmosOutboxSettingsExtensions.cs
@@ -8,7 +8,7 @@ namespace NServiceBus
     /// <summary>
     /// Cosmos DB outbox settings
     /// </summary>
-    public static class CosmosDBOutboxSettingsExtensions
+    public static class CosmosOutboxSettingsExtensions
     {
         /// <summary>
         /// Sets the time to live for outbox deduplication records

--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxStorage.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxStorage.cs
@@ -19,7 +19,7 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var serializer = new JsonSerializer {ContractResolver = new CosmosDBContractResolver()};
+            var serializer = new JsonSerializer {ContractResolver = new UpperCaseIdIntoLowerCaseIdContractResolver()};
 
             var ttlInSeconds = context.Settings.Get<int>(SettingsKeys.OutboxTimeToLiveInSeconds);
 

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosSagaIdGenerator.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosSagaIdGenerator.cs
@@ -5,7 +5,7 @@
     using System.Text;
     using Newtonsoft.Json;
 
-    static class CosmosDBSagaIdGenerator
+    static class CosmosSagaIdGenerator
     {
         public static Guid Generate(Type sagaEntityType, string correlationPropertyName, object correlationPropertyValue) => Generate(sagaEntityType.FullName, correlationPropertyName, correlationPropertyValue);
 

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaIdGenerator.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaIdGenerator.cs
@@ -12,7 +12,7 @@
                 throw new Exception("The CosmosDB saga persister doesn't support custom saga finders.");
             }
 
-            return CosmosDBSagaIdGenerator.Generate(context.SagaMetadata.SagaEntityType, context.CorrelationProperty.Name, context.CorrelationProperty.Value);
+            return CosmosSagaIdGenerator.Generate(context.SagaMetadata.SagaEntityType, context.CorrelationProperty.Name, context.CorrelationProperty.Value);
         }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersistence.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersistence.cs
@@ -19,7 +19,7 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var serializer = new JsonSerializer {ContractResolver = new CosmosDBContractResolver()};
+            var serializer = new JsonSerializer {ContractResolver = new UpperCaseIdIntoLowerCaseIdContractResolver()};
 
             var migrationModeEnabled = context.Settings.GetOrDefault<bool>(SettingsKeys.EnableMigrationMode);
 

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersister.cs
@@ -89,7 +89,7 @@
             var storageSession = (StorageSession)session;
 
             // Saga ID needs to be calculated the same way as in SagaIdGenerator does
-            var sagaId = CosmosDBSagaIdGenerator.Generate(typeof(TSagaData), propertyName, propertyValue);
+            var sagaId = CosmosSagaIdGenerator.Generate(typeof(TSagaData), propertyName, propertyValue);
 
             // reads need to go directly
             var container = storageSession.ContainerHolder.Container;

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/ICosmosStorageSession.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/ICosmosStorageSession.cs
@@ -5,7 +5,7 @@
     /// <summary>
     ///
     /// </summary>
-    public interface ICosmosDBStorageSession
+    public interface ICosmosStorageSession
     {
         /// <summary>
         /// The partition key

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/IWorkWithSharedTransactionalBatchExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/IWorkWithSharedTransactionalBatchExtensions.cs
@@ -6,7 +6,7 @@
 
     static class IWorkWithSharedTransactionalBatchExtensions
     {
-        public static ICosmosDBStorageSession Create(this IWorkWithSharedTransactionalBatch workWith)
+        public static ICosmosStorageSession Create(this IWorkWithSharedTransactionalBatch workWith)
         {
             if (!workWith.CurrentContextBag.TryGet<PartitionKey>(out var partitionKey))
             {

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SharedTransactionalBatch.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SharedTransactionalBatch.cs
@@ -6,7 +6,7 @@
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
 
-    sealed class SharedTransactionalBatch : TransactionalBatch, ICosmosDBStorageSession
+    sealed class SharedTransactionalBatch : TransactionalBatch, ICosmosStorageSession
     {
         public SharedTransactionalBatch(IWorkWithSharedTransactionalBatch operationsHolder, PartitionKey partitionKey)
         {

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorageSessionExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorageSessionExtensions.cs
@@ -22,7 +22,7 @@
                 return workWith.Create().Batch;
             }
 
-            throw new Exception($"Cannot access the synchronized storage session. Ensure that 'EndpointConfiguration.UsePersistence<{nameof(CosmosDbPersistence)}>()' has been called.");
+            throw new Exception($"Cannot access the synchronized storage session. Ensure that 'EndpointConfiguration.UsePersistence<{nameof(CosmosPersistence)}>()' has been called.");
         }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Utility/UpperCaseIdIntoLowerCaseIdContractResolver.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Utility/UpperCaseIdIntoLowerCaseIdContractResolver.cs
@@ -4,7 +4,7 @@
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
 
-    class CosmosDBContractResolver : DefaultContractResolver
+    class UpperCaseIdIntoLowerCaseIdContractResolver : DefaultContractResolver
     {
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_outbox_synchronized_session_via_container.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_outbox_synchronized_session_via_container.cs
@@ -71,7 +71,7 @@
 
         public class MyRepository
         {
-            public MyRepository(ICosmosDBStorageSession storageSession, Context context)
+            public MyRepository(ICosmosStorageSession storageSession, Context context)
             {
                 this.storageSession = storageSession;
                 this.context = context;
@@ -85,7 +85,7 @@
                 context.PartitionKeyPath = storageSession.PartitionKeyPath;
             }
 
-            ICosmosDBStorageSession storageSession;
+            ICosmosStorageSession storageSession;
             Context context;
         }
 

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container.cs
@@ -35,7 +35,7 @@
 
             public class MyHandler : IHandleMessages<MyMessage>
             {
-                public MyHandler(ICosmosDBStorageSession session, Context context)
+                public MyHandler(ICosmosStorageSession session, Context context)
                 {
                     this.session = session;
                     this.context = context;
@@ -50,7 +50,7 @@
                 }
 
                 Context context;
-                ICosmosDBStorageSession session;
+                ICosmosStorageSession session;
             }
         }
 

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container_and_storage_session_extension.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container_and_storage_session_extension.cs
@@ -40,7 +40,7 @@
 
             public class MyHandlerUsingStorageSession : IHandleMessages<MyMessage>
             {
-                public MyHandlerUsingStorageSession(ICosmosDBStorageSession session, Context context)
+                public MyHandlerUsingStorageSession(ICosmosStorageSession session, Context context)
                 {
                     this.session = session;
                     this.context = context;
@@ -63,7 +63,7 @@
                 }
 
                 Context context;
-                ICosmosDBStorageSession session;
+                ICosmosStorageSession session;
             }
 
             public class MyHandlerUsingExtensionMethod : IHandleMessages<MyMessage>

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container_and_storage_session_fails.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container_and_storage_session_fails.cs
@@ -44,7 +44,7 @@
 
             public class MyHandlerUsingStorageSession : IHandleMessages<MyMessage>
             {
-                public MyHandlerUsingStorageSession(ICosmosDBStorageSession session, Context context)
+                public MyHandlerUsingStorageSession(ICosmosStorageSession session, Context context)
                 {
                     this.session = session;
                     this.context = context;
@@ -67,7 +67,7 @@
                 }
 
                 Context context;
-                ICosmosDBStorageSession session;
+                ICosmosStorageSession session;
             }
 
             public class MyHandlerUsingExtensionMethod : IHandleMessages<MyMessage>


### PR DESCRIPTION
As discussed we keep `CosmosDB` into package name, repository name as well as in the namespace but use `Cosmos` only for the types which follows the same reasoning applied to MongoDB persistence

Example

- [Persistence Definition](https://github.com/Particular/NServiceBus.Storage.MongoDB/blob/master/src/NServiceBus.Storage.MongoDB/MongoPersistence.cs#L12)
 - [Namespace](https://github.com/Particular/NServiceBus.Storage.MongoDB/blob/master/src/NServiceBus.Storage.MongoDB/Outbox/MongoOutboxTransaction.cs#L1)