### PR TITLE
Fully expose the whole storage session when accessed via SynchronizedStorageSession

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -44,7 +44,7 @@ namespace NServiceBus
     }
     public class static SynchronizedStorageSessionExtensions
     {
-        public static Microsoft.Azure.Cosmos.TransactionalBatch GetSharedTransactionalBatch(this NServiceBus.Persistence.SynchronizedStorageSession session) { }
+        public static NServiceBus.ICosmosStorageSession CosmosPersistenceSession(this NServiceBus.Persistence.SynchronizedStorageSession session) { }
     }
 }
 namespace NServiceBus.Persistence.CosmosDB

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/SynchronizedStorage/TestableCosmosSynchronizedStorageSessionTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/SynchronizedStorage/TestableCosmosSynchronizedStorageSessionTests.cs
@@ -92,9 +92,9 @@
         {
             public Task Handle(MyMessage message, IMessageHandlerContext context)
             {
-                var batch = context.SynchronizedStorageSession.GetSharedTransactionalBatch();
+                var session = context.SynchronizedStorageSession.CosmosPersistenceSession();
                 var myItem = new MyItem();
-                batch.CreateItem(myItem);
+                session.Batch.CreateItem(myItem);
                 return Task.CompletedTask;
             }
         }

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorageSessionExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/SynchronizedStorageSessionExtensions.cs
@@ -11,15 +11,15 @@
     public static class SynchronizedStorageSessionExtensions
     {
         /// <summary>
-        /// Retrieves the shared <see cref="TransactionalBatch"/> from the <see cref="SynchronizedStorageSession"/>.
+        /// Retrieves the shared <see cref="ICosmosStorageSession"/> from the <see cref="SynchronizedStorageSession"/>.
         /// </summary>
-        public static TransactionalBatch GetSharedTransactionalBatch(this SynchronizedStorageSession session)
+        public static ICosmosStorageSession CosmosPersistenceSession(this SynchronizedStorageSession session)
         {
             Guard.AgainstNull(nameof(session), session);
 
             if (session is IWorkWithSharedTransactionalBatch workWith)
             {
-                return workWith.Create().Batch;
+                return workWith.Create();
             }
 
             throw new Exception($"Cannot access the synchronized storage session. Ensure that 'EndpointConfiguration.UsePersistence<{nameof(CosmosPersistence)}>()' has been called.");

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container_and_storage_session_extension.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container_and_storage_session_extension.cs
@@ -75,9 +75,9 @@
 
                 public Task Handle(MyMessage message, IMessageHandlerContext handlerContext)
                 {
-                    var transactionalBatch = handlerContext.SynchronizedStorageSession.GetSharedTransactionalBatch();
+                    var session = handlerContext.SynchronizedStorageSession.CosmosPersistenceSession();
 
-                    transactionalBatch.CreateItem(new
+                    session.Batch.CreateItem(new
                     {
                         id = Context.Item2_Id,
                         deep = new

--- a/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container_and_storage_session_fails.cs
+++ b/src/SharedAcceptanceTests.RequirePartitionKey/When_using_synchronized_session_via_container_and_storage_session_fails.cs
@@ -79,9 +79,9 @@
 
                 public Task Handle(MyMessage message, IMessageHandlerContext handlerContext)
                 {
-                    var transactionalBatch = handlerContext.SynchronizedStorageSession.GetSharedTransactionalBatch();
+                    var session = handlerContext.SynchronizedStorageSession.CosmosPersistenceSession();
 
-                    transactionalBatch.CreateItem(new
+                    session.Batch.CreateItem(new
                     {
                         id = Context.Item2_Id,
                         deep = new


### PR DESCRIPTION
This PR fully exposes the synchronized storage session instead of just the transactional batch.

Previously we only exposed the transactional batch because that was the only thing the storage session provided and thus this approach was similar to MongoDB. 

With the introduction of #64 the storage session exposed now much more valuable information than just the batch. All other persisters that expose multiple things on the storage session also return the storage session itself therefore I think we should follow that as well and expose the full session. 