### PR TITLE
Set schema version to 0.1.0

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxPersister.cs
@@ -90,7 +90,7 @@
         readonly JsonSerializer serializer;
         readonly int ttlInSeconds;
 
-        internal static readonly string SchemaVersion = "1.0.0";
+        internal static readonly string SchemaVersion = "0.1.0";
         ContainerHolderResolver containerHolderResolver;
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaSchemaVersion.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaSchemaVersion.cs
@@ -2,6 +2,6 @@
 {
     static class SagaSchemaVersion
     {
-        internal static readonly string Current = "1.0.0";
+        internal static readonly string Current = "0.1.0";
     }
 }


### PR DESCRIPTION
Updates hard-coded schema version to `0.1.0`, as discussed in yesterday's sync.

#72 is an alternative to this PR that instead uses `GitVersionInformation` instead of a hard-coded value.