### PR TITLE
Store major/minor version instead of "schema version"

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/Exporter.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/Exporter.cs
@@ -127,7 +127,8 @@
 
             var metadata = new JObject
             {
-                {MetadataExtensions.SagaDataContainerSchemaVersionMetadataKey, SagaSchemaVersion.Current},
+                {MetadataExtensions.MajorVersion, GitVersionInformation.Major },
+                {MetadataExtensions.MinorVersion, GitVersionInformation.Minor },
                 {MetadataExtensions.SagaDataContainerFullTypeNameMetadataKey, sagaDataTypeFullName},
                 {MetadataExtensions.SagaDataContainerMigratedSagaIdMetadataKey, oldSagaId.ToString()}
             };

--- a/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter/NServiceBus.Persistence.CosmosDB.AzureStorageSagaExporter.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <Compile Include="..\NServiceBus.Persistence.CosmosDB\MetadataExtensions.cs" Link="MetadataExtensions.Common.cs" />
     <Compile Include="..\NServiceBus.Persistence.CosmosDB\Saga\MetadataExtensions.cs" Link="MetadataExtensions.Sagas.cs" />
-    <Compile Include="..\NServiceBus.Persistence.CosmosDB\Saga\SagaSchemaVersion.cs" Link="SagaSchemaVersion.cs" />
     <Compile Include="..\NServiceBus.Persistence.CosmosDB\Saga\CosmosSagaIdGenerator.cs" Link="CosmosSagaIdGenerator.cs" />
     <Compile Include="..\TestSuppressions.cs" Link="TestSuppressions.cs" />
   </ItemGroup>

--- a/src/NServiceBus.Persistence.CosmosDB/MetadataExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/MetadataExtensions.cs
@@ -3,6 +3,7 @@
     static partial class MetadataExtensions
     {
         internal const string MetadataKey = "_NServiceBus-Persistence-Metadata";
-        internal const string MetadataKeySchemaVersionSuffix = "-SchemaVersion";
+        internal const string MajorVersion = MetadataKey + "-Major-Version";
+        internal const string MinorVersion = MetadataKey + "-Minor-Version";
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/MetadataExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/MetadataExtensions.cs
@@ -2,7 +2,6 @@
 {
     static partial class MetadataExtensions
     {
-        internal const string OutboxDataContainerSchemaVersionMetadataKey = "OutboxDataContainer" + MetadataKeySchemaVersionSuffix;
         internal const string OutboxDataContainerFullTypeNameMetadataKey = "OutboxDataContainer-FullTypeName";
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxOperations.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxOperations.cs
@@ -36,7 +36,8 @@
 
             var metadata = new JObject
             {
-                { MetadataExtensions.OutboxDataContainerSchemaVersionMetadataKey, OutboxPersister.SchemaVersion },
+                { MetadataExtensions.MajorVersion, GitVersionInformation.Major },
+                { MetadataExtensions.MinorVersion, GitVersionInformation.Minor },
                 { MetadataExtensions.OutboxDataContainerFullTypeNameMetadataKey, typeof(OutboxRecord).FullName }
             };
             jObject.Add(MetadataExtensions.MetadataKey, metadata);
@@ -69,7 +70,8 @@
 
             var metadata = new JObject
             {
-                { MetadataExtensions.OutboxDataContainerSchemaVersionMetadataKey, OutboxPersister.SchemaVersion },
+                { MetadataExtensions.MajorVersion, GitVersionInformation.Major },
+                { MetadataExtensions.MinorVersion, GitVersionInformation.Minor },
                 { MetadataExtensions.OutboxDataContainerFullTypeNameMetadataKey, typeof(OutboxRecord).FullName }
             };
             jObject.Add(MetadataExtensions.MetadataKey, metadata);

--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxPersister.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxPersister.cs
@@ -90,7 +90,6 @@
         readonly JsonSerializer serializer;
         readonly int ttlInSeconds;
 
-        internal static readonly string SchemaVersion = "1.0.0";
         ContainerHolderResolver containerHolderResolver;
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/MetadataExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/MetadataExtensions.cs
@@ -2,7 +2,6 @@
 {
     static partial class MetadataExtensions
     {
-        internal const string SagaDataContainerSchemaVersionMetadataKey = "SagaDataContainer" + MetadataKeySchemaVersionSuffix;
         internal const string SagaDataContainerFullTypeNameMetadataKey = "SagaDataContainer-FullTypeName";
         internal const string SagaDataContainerMigratedSagaIdMetadataKey = "SagaDataContainer-MigratedSagaId";
     }

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaOperations.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaOperations.cs
@@ -47,7 +47,8 @@
 
             var metadata = new JObject
             {
-                { MetadataExtensions.SagaDataContainerSchemaVersionMetadataKey, SagaSchemaVersion.Current },
+                { MetadataExtensions.MajorVersion, GitVersionInformation.Major },
+                { MetadataExtensions.MinorVersion, GitVersionInformation.Minor },
                 { MetadataExtensions.SagaDataContainerFullTypeNameMetadataKey, sagaData.GetType().FullName }
             };
             jObject.Add(MetadataExtensions.MetadataKey,metadata);
@@ -81,7 +82,8 @@
 
             var metadata = new JObject
             {
-                { MetadataExtensions.SagaDataContainerSchemaVersionMetadataKey, SagaSchemaVersion.Current },
+                { MetadataExtensions.MajorVersion, GitVersionInformation.Major },
+                { MetadataExtensions.MinorVersion, GitVersionInformation.Minor },
                 { MetadataExtensions.SagaDataContainerFullTypeNameMetadataKey, sagaData.GetType().FullName }
             };
 

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaSchemaVersion.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaSchemaVersion.cs
@@ -1,7 +1,0 @@
-﻿namespace NServiceBus.Persistence.CosmosDB
-{
-    static class SagaSchemaVersion
-    {
-        internal static readonly string Current = "1.0.0";
-    }
-}


### PR DESCRIPTION
This is an alternative to #71 which hard codes a "schema version" to `0.1.0`

Instead, use `GitVersionInformation` to store the Major and Minor version in the metadata. 

This has the advantage of not needing to be remembered as part of the update, although an API comparer solution could probably be created to solve that problem as an alternative to this solution.

They are stored as separate values to make querying easier since there is no easy way to write a greater than/less than WHERE statements for dot notation version information.

This also removes the need for shared files since both the export tool and the persister both generate `GitVersionInformation`.

The downside to this approach is the reliance on the `GitVersion` package at runtime, but I do not think this is an overwhelming negative.