### PR TITLE
Move the provider to the component namespace

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -32,10 +32,6 @@ namespace NServiceBus
         Microsoft.Azure.Cosmos.PartitionKey PartitionKey { get; }
         NServiceBus.PartitionKeyPath PartitionKeyPath { get; }
     }
-    public interface IProvideCosmosClient
-    {
-        Microsoft.Azure.Cosmos.CosmosClient Client { get; }
-    }
     public readonly struct PartitionKeyPath
     {
         public PartitionKeyPath(string partitionKeyPath) { }
@@ -49,6 +45,10 @@ namespace NServiceBus
 }
 namespace NServiceBus.Persistence.CosmosDB
 {
+    public interface IProvideCosmosClient
+    {
+        Microsoft.Azure.Cosmos.CosmosClient Client { get; }
+    }
     public sealed class LogicalOutboxBehavior : NServiceBus.Pipeline.IBehavior, NServiceBus.Pipeline.IBehavior<NServiceBus.Pipeline.IIncomingLogicalMessageContext, NServiceBus.Pipeline.IIncomingLogicalMessageContext>
     {
         public System.Threading.Tasks.Task Invoke(NServiceBus.Pipeline.IIncomingLogicalMessageContext context, System.Func<NServiceBus.Pipeline.IIncomingLogicalMessageContext, System.Threading.Tasks.Task> next) { }

--- a/src/NServiceBus.Persistence.CosmosDB/Config/IProvideCosmosClient.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/IProvideCosmosClient.cs
@@ -1,10 +1,10 @@
-﻿namespace NServiceBus
+﻿namespace NServiceBus.Persistence.CosmosDB
 {
     using Microsoft.Azure.Cosmos;
 
     /// <summary>
     /// Provides a CosmosClient via dependency injection. A custom implementation can be registered on the container and will be picked up by the persistence.
-    /// <remarks>     
+    /// <remarks>
     /// The client provided will not be disposed by the persistence. It is the responsibility of the provider to take care of proper resource disposal if necessary.
     /// </remarks>
     /// </summary>

--- a/src/SharedAcceptanceTests.All/When_custom_provider_registered.cs
+++ b/src/SharedAcceptanceTests.All/When_custom_provider_registered.cs
@@ -6,6 +6,7 @@
     using EndpointTemplates;
     using Microsoft.Azure.Cosmos;
     using NUnit.Framework;
+    using Persistence.CosmosDB;
 
     public class When_custom_provider_registered : NServiceBusAcceptanceTest
     {


### PR DESCRIPTION
While doing the Azure enhancement release we realized having the providers in the root namespace is problematic as soon as you have multiple components that want to register the same third party type. So we decided to move the providers to the component namespace. 