### PR TITLE
Align Operation.Conflict exception types

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxOperations.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxOperations.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Persistence.CosmosDB
 {
-    using System;
     using System.IO;
     using System.Text;
     using Extensibility;
@@ -89,7 +88,7 @@
 
         public override void Conflict(TransactionalBatchOperationResult result)
         {
-            throw new Exception($"The outbox record with id '{record.Id}' could not be marked as dispatched, it was updated by another process.");
+            throw new TransactionalBatchOperationException($"The outbox record with id '{record.Id}' could not be marked as dispatched. Response status code: {result.StatusCode}.", result);
         }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaOperations.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaOperations.cs
@@ -38,7 +38,7 @@
 
         public override void Conflict(TransactionalBatchOperationResult result)
         {
-            throw new Exception($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be created possibly due to a concurrency conflict.");
+            throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' can't be completed. Response status code: {result.StatusCode}.", result);
         }
 
         public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)
@@ -72,7 +72,7 @@
 
         public override void Conflict(TransactionalBatchOperationResult result)
         {
-            throw new Exception($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' was updated by another process or no longer exists.");
+            throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' can't be completed. Response status code: {result.StatusCode}.", result);
         }
 
         public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)
@@ -116,7 +116,7 @@
 
         public override void Conflict(TransactionalBatchOperationResult result)
         {
-            throw new Exception($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' can't be completed because it was updated by another process.");
+            throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' can't be completed. Response status code: {result.StatusCode}.", result);
         }
 
         public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)


### PR DESCRIPTION
The overrides of `Operation.Conflict` for Saga and Outbox operations throw a generic `Exception` without further details, strictly assuming that this can only happen due to concurrency conflicts. However, these operations can based on user experience at least also run into `429` (throttling) errors. Identifying the underlying cause, e.g. when using a custom recoverability policy is not possible without providing better information about the actual error. The [default Operation.Conflict implementation](https://github.com/Particular/NServiceBus.Persistence.CosmosDB/blob/master/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/Operation.cs#L26) does already throw `TransactionalBatchOperationException`  so this just aligns the behavior.