### PR TITLE
Add status code to TransactionalBatchOperationException message

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/TransactionalBatchOperationException.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/TransactionalBatchOperationException.cs
@@ -12,7 +12,7 @@
         /// <summary>
         /// Initializes a new TransactionalBatchOperationException with a <see cref="TransactionalBatchOperationResult"/>.
         /// </summary>
-        public TransactionalBatchOperationException(TransactionalBatchOperationResult result)
+        public TransactionalBatchOperationException(TransactionalBatchOperationResult result) : base(result.StatusCode.ToString("G"))
         {
             Result = result;
         }


### PR DESCRIPTION
When not already providing a message to the `TransactionalBatchOperationException` ctor, error information from `TransactionalBatchOperationException` from stack traces are basically useless as there is no information from the `Result` property mentioned. This is a small change to at least include the HTTP status code to give a hint of the involved issue for better diagnosis.