### PR TITLE
Throw if endpoint configured for message-driven pub/sub

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxStorage.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxStorage.cs
@@ -19,6 +19,8 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
+            NonNativePubSubCheck.ThrowIfMessageDrivenPubSubInUse(context);
+
             var serializer = new JsonSerializer { ContractResolver = new UpperCaseIdIntoLowerCaseIdContractResolver() };
 
             var ttlInSeconds = context.Settings.Get<int>(SettingsKeys.OutboxTimeToLiveInSeconds);

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersistence.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaPersistence.cs
@@ -19,6 +19,8 @@
 
         protected override void Setup(FeatureConfigurationContext context)
         {
+            NonNativePubSubCheck.ThrowIfMessageDrivenPubSubInUse(context);
+
             var serializer = new JsonSerializer { ContractResolver = new UpperCaseIdIntoLowerCaseIdContractResolver() };
 
             var migrationModeEnabled = context.Settings.GetOrDefault<bool>(SettingsKeys.EnableMigrationMode);

--- a/src/NServiceBus.Persistence.CosmosDB/Utility/NonNativePubSubCheck.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Utility/NonNativePubSubCheck.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System;
+    using NServiceBus.Features;
+
+    class NonNativePubSubCheck
+    {
+        public static void ThrowIfMessageDrivenPubSubInUse(FeatureConfigurationContext context)
+        {
+            if (context.Settings.IsFeatureEnabled(typeof(MessageDrivenSubscriptions)) || context.Settings.IsFeatureActive(typeof(MessageDrivenSubscriptions)))
+            {
+                throw new Exception("NServiceBus.Persistence.CosmosDB must be used with a transport that provides native publish/subscribe capabilities, and cannot be used with message-driven publish/subscribe.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Acts as a fix to https://github.com/Particular/NServiceBus.Persistence.CosmosDB/issues/186 by preventing the persistence from running in an unsupported configuration.