### PR TITLE
Cache partition key path and segments

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -34,8 +34,13 @@ namespace NServiceBus
     public readonly struct PartitionKeyPath
     {
         public PartitionKeyPath(string partitionKeyPath) { }
+        public bool Equals(NServiceBus.PartitionKeyPath other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
         public override string ToString() { }
         public static string op_Implicit(NServiceBus.PartitionKeyPath path) { }
+        public static bool operator !=(NServiceBus.PartitionKeyPath left, NServiceBus.PartitionKeyPath right) { }
+        public static bool operator ==(NServiceBus.PartitionKeyPath left, NServiceBus.PartitionKeyPath right) { }
     }
     public static class SynchronizedStorageSessionExtensions
     {

--- a/src/NServiceBus.Persistence.CosmosDB/Config/PartitionKeyPath.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/PartitionKeyPath.cs
@@ -12,23 +12,35 @@
         /// </summary>
         /// <param name="partitionKeyPath">The partition key path.</param>\
         /// <remarks>No validation is done to assert whether the provided path matches the Cosmos DB conventions.</remarks>
-        public PartitionKeyPath(string partitionKeyPath)
-        {
-            this.partitionKeyPath = partitionKeyPath;
-        }
+        public PartitionKeyPath(string partitionKeyPath) => this.partitionKeyPath = partitionKeyPath;
 
         /// <summary>
         /// Implicitly converts the partition key path into a string.
         /// </summary>
-        public static implicit operator string(PartitionKeyPath path)
-        {
-            return path.partitionKeyPath;
-        }
+        public static implicit operator string(PartitionKeyPath path) => path.partitionKeyPath;
 
         /// <inheritdoc />
-        public override string ToString()
-        {
-            return partitionKeyPath;
-        }
+        public override string ToString() => partitionKeyPath;
+
+        /// <summary>
+        /// Compares two partition key paths.
+        /// </summary>
+        public bool Equals(PartitionKeyPath other) => partitionKeyPath == other.partitionKeyPath;
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => obj is PartitionKeyPath other && Equals(other);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => partitionKeyPath != null ? partitionKeyPath.GetHashCode() : 0;
+
+        /// <summary>
+        /// Compares to partition key paths for equality.
+        /// </summary>
+        public static bool operator ==(PartitionKeyPath left, PartitionKeyPath right) => left.Equals(right);
+
+        /// <summary>
+        /// Compares two partition key path for inequality.
+        /// </summary>
+        public static bool operator !=(PartitionKeyPath left, PartitionKeyPath right) => !left.Equals(right);
     }
 }


### PR DESCRIPTION
The cardinality of the partition key paths is low, so we can cache the path and the segments