### PR TITLE
Validation and rename of the pessimistic configuration

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -79,7 +79,7 @@
                 var pessimisticLockingConfiguration = sagaPersistenceConfiguration.UsePessimisticLocking();
                 if (SessionTimeout.HasValue)
                 {
-                    pessimisticLockingConfiguration.SetPessimisticLeaseLockAcquisitionTimeout(SessionTimeout.Value);
+                    pessimisticLockingConfiguration.SetLeaseLockAcquisitionTimeout(SessionTimeout.Value);
                 }
                 SupportsPessimisticConcurrency = true;
             }

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -74,10 +74,10 @@ namespace NServiceBus.Persistence.CosmosDB
     public class PessimisticLockingConfiguration
     {
         public PessimisticLockingConfiguration() { }
-        public void SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(System.TimeSpan value) { }
-        public void SetPessimisticLeaseLockAcquisitionMinimumRefreshDelay(System.TimeSpan value) { }
-        public void SetPessimisticLeaseLockAcquisitionTimeout(System.TimeSpan value) { }
-        public void SetPessimisticLeaseLockTime(System.TimeSpan value) { }
+        public void SetLeaseLockAcquisitionMaximumRefreshDelay(System.TimeSpan value) { }
+        public void SetLeaseLockAcquisitionMinimumRefreshDelay(System.TimeSpan value) { }
+        public void SetLeaseLockAcquisitionTimeout(System.TimeSpan value) { }
+        public void SetLeaseLockTime(System.TimeSpan value) { }
     }
     public class SagaPersistenceConfiguration
     {

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
@@ -23,7 +23,7 @@
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockTime(TimeSpan.Zero));
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockTime(TimeSpan.Zero));
         }
 
         [Test]
@@ -33,7 +33,7 @@
 
             var fromMinutes = TimeSpan.FromMinutes(minutes);
 
-            configuration.SetPessimisticLeaseLockTime(fromMinutes);
+            configuration.SetLeaseLockTime(fromMinutes);
 
             Assert.AreEqual(fromMinutes, configuration.LeaseLockTime);
         }
@@ -43,7 +43,7 @@
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionTimeout(TimeSpan.Zero));
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionTimeout(TimeSpan.Zero));
         }
 
         [Test]
@@ -53,7 +53,7 @@
 
             var fromMinutes = TimeSpan.FromMilliseconds(minutes);
 
-            configuration.SetPessimisticLeaseLockTime(fromMinutes);
+            configuration.SetLeaseLockTime(fromMinutes);
 
             Assert.AreEqual(fromMinutes, configuration.LeaseLockTime);
         }
@@ -63,7 +63,7 @@
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.Zero));
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.Zero));
         }
 
         [Test]
@@ -71,7 +71,7 @@
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.FromMilliseconds(milliseconds)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.FromMilliseconds(milliseconds)));
         }
 
         [Test]
@@ -81,7 +81,7 @@
 
             var fromMilliseconds = TimeSpan.FromMilliseconds(milliseconds);
 
-            configuration.SetPessimisticLeaseLockAcquisitionMinimumRefreshDelay(fromMilliseconds);
+            configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(fromMilliseconds);
 
             Assert.AreEqual(fromMilliseconds, configuration.LeaseLockAcquisitionMinimumRefreshDelay);
         }
@@ -91,7 +91,7 @@
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.Zero));
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.Zero));
         }
 
         [Test]
@@ -99,7 +99,7 @@
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.FromMilliseconds(milliseconds)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.FromMilliseconds(milliseconds)));
         }
 
         [Test]
@@ -109,7 +109,7 @@
 
             var fromMilliseconds = TimeSpan.FromMilliseconds(milliseconds);
 
-            configuration.SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(fromMilliseconds);
+            configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(fromMilliseconds);
 
             Assert.AreEqual(fromMilliseconds, configuration.LeaseLockAcquisitionMaximumRefreshDelay);
         }

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
@@ -67,19 +67,19 @@
         }
 
         [Test]
-        public void Should_throw_bigger_value_than_maximum_refresh_delay_for_minimum_refresh_delay([Random(1001, 1100, 5, Distinct = true)] double milliseconds)
+        public void Should_throw_bigger_value_than_maximum_refresh_delay_for_minimum_refresh_delay([Random(1001, 1100, 5, Distinct = true)] double millisecondsBiggerThanMaximumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.FromMilliseconds(milliseconds)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.FromMilliseconds(millisecondsBiggerThanMaximumRefreshDelayDefaultValue)));
         }
 
         [Test]
-        public void Should_set_minimum_refresh_delay([Random(1, 1000, 5, Distinct = true)] double milliseconds)
+        public void Should_set_minimum_refresh_delay([Random(1, 1000, 5, Distinct = true)] double millisecondsSmallerThanMaximumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            var fromMilliseconds = TimeSpan.FromMilliseconds(milliseconds);
+            var fromMilliseconds = TimeSpan.FromMilliseconds(millisecondsSmallerThanMaximumRefreshDelayDefaultValue);
 
             configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(fromMilliseconds);
 
@@ -95,19 +95,19 @@
         }
 
         [Test]
-        public void Should_throw_smaller_value_than_minimum_refresh_delay_for_maximum_refresh_delay([Random(1, 499, 5, Distinct = true)] double milliseconds)
+        public void Should_throw_smaller_value_than_minimum_refresh_delay_for_maximum_refresh_delay([Random(1, 499, 5, Distinct = true)] double millisecondsSmallerThanMinimumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.FromMilliseconds(milliseconds)));
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.FromMilliseconds(millisecondsSmallerThanMinimumRefreshDelayDefaultValue)));
         }
 
         [Test]
-        public void Should_set_maximum_refresh_delay([Random(500, 1500, 5, Distinct = true)] double milliseconds)
+        public void Should_set_maximum_refresh_delay([Random(500, 1500, 5, Distinct = true)] double millisecondsBiggerThanMinimumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
-            var fromMilliseconds = TimeSpan.FromMilliseconds(milliseconds);
+            var fromMilliseconds = TimeSpan.FromMilliseconds(millisecondsBiggerThanMinimumRefreshDelayDefaultValue);
 
             configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(fromMilliseconds);
 

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.Persistence.CosmosDB.Tests.Saga
+{
+    using System;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class PessimisticLockingConfigurationTests
+    {
+        [Test]
+        public void Should_have_default_values()
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            Assert.That(configuration.LeaseLockTime, Is.EqualTo(TimeSpan.FromMinutes(1)));
+            Assert.That(configuration.LeaseLockAcquisitionTimeout, Is.EqualTo(TimeSpan.FromMinutes(1)));
+            Assert.That(configuration.LeaseLockAcquisitionMinimumRefreshDelay, Is.EqualTo(TimeSpan.FromMilliseconds(500)));
+            Assert.That(configuration.LeaseLockAcquisitionMaximumRefreshDelay, Is.EqualTo(TimeSpan.FromMilliseconds(1000)));
+            Assert.That(configuration.PessimisticLockingEnabled, Is.False);
+        }
+
+        [Test]
+        public void Should_throw_on_zero_value_for_lease_lock_time()
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockTime(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void Should_set_lease_lock_time([Random(1, 10, 5, Distinct = true)] double minutes)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            var fromMinutes = TimeSpan.FromMinutes(minutes);
+
+            configuration.SetPessimisticLeaseLockTime(fromMinutes);
+
+            Assert.AreEqual(fromMinutes, configuration.LeaseLockTime);
+        }
+
+        [Test]
+        public void Should_throw_on_zero_value_for_lease_lock_acquisition_timeout()
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionTimeout(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void Should_set_lease_lock_acquisition_timeout([Random(1, 10, 5, Distinct = true)] double minutes)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            var fromMinutes = TimeSpan.FromMilliseconds(minutes);
+
+            configuration.SetPessimisticLeaseLockTime(fromMinutes);
+
+            Assert.AreEqual(fromMinutes, configuration.LeaseLockTime);
+        }
+
+        [Test]
+        public void Should_throw_on_zero_value_for_minimum_refresh_delay()
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void Should_throw_bigger_value_than_maximum_refresh_delay_for_minimum_refresh_delay([Random(1001, 1100, 5, Distinct = true)] double milliseconds)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.FromMilliseconds(milliseconds)));
+        }
+
+        [Test]
+        public void Should_set_minimum_refresh_delay([Random(1, 1000, 5, Distinct = true)] double milliseconds)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            var fromMilliseconds = TimeSpan.FromMilliseconds(milliseconds);
+
+            configuration.SetPessimisticLeaseLockAcquisitionMinimumRefreshDelay(fromMilliseconds);
+
+            Assert.AreEqual(fromMilliseconds, configuration.LeaseLockAcquisitionMinimumRefreshDelay);
+        }
+
+        [Test]
+        public void Should_throw_on_zero_value_for_maximum_refresh_delay()
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.Zero));
+        }
+
+        [Test]
+        public void Should_throw_smaller_value_than_minimum_refresh_delay_for_maximum_refresh_delay([Random(1, 499, 5, Distinct = true)] double milliseconds)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.FromMilliseconds(milliseconds)));
+        }
+
+        [Test]
+        public void Should_set_maximum_refresh_delay([Random(500, 1500, 5, Distinct = true)] double milliseconds)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+
+            var fromMilliseconds = TimeSpan.FromMilliseconds(milliseconds);
+
+            configuration.SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(fromMilliseconds);
+
+            Assert.AreEqual(fromMilliseconds, configuration.LeaseLockAcquisitionMaximumRefreshDelay);
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
@@ -67,7 +67,7 @@
         }
 
         [Test]
-        public void Should_throw_bigger_value_than_maximum_refresh_delay_for_minimum_refresh_delay([Random(1001, 1100, 5, Distinct = true)] double millisecondsBiggerThanMaximumRefreshDelayDefaultValue)
+        public void Should_throw_bigger_value_than_maximum_refresh_delay_default_for_minimum_refresh_delay([Random(1001, 1100, 5, Distinct = true)] double millisecondsBiggerThanMaximumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
@@ -75,7 +75,7 @@
         }
 
         [Test]
-        public void Should_set_minimum_refresh_delay([Random(1, 1000, 5, Distinct = true)] double millisecondsSmallerThanMaximumRefreshDelayDefaultValue)
+        public void Should_set_minimum_refresh_delay_when_below_default_maximum_refresh_delay([Random(1, 1000, 5, Distinct = true)] double millisecondsSmallerThanMaximumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
@@ -95,7 +95,7 @@
         }
 
         [Test]
-        public void Should_throw_smaller_value_than_minimum_refresh_delay_for_maximum_refresh_delay([Random(1, 499, 5, Distinct = true)] double millisecondsSmallerThanMinimumRefreshDelayDefaultValue)
+        public void Should_throw_smaller_value_than_minimum_refresh_delay_default_for_maximum_refresh_delay([Random(1, 499, 5, Distinct = true)] double millisecondsSmallerThanMinimumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
@@ -103,7 +103,7 @@
         }
 
         [Test]
-        public void Should_set_maximum_refresh_delay([Random(500, 1500, 5, Distinct = true)] double millisecondsBiggerThanMinimumRefreshDelayDefaultValue)
+        public void Should_set_maximum_refresh_delay_when_above_default_minimum_refresh_delay([Random(500, 1500, 5, Distinct = true)] double millisecondsBiggerThanMinimumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/PessimisticLockingConfigurationTests.cs
@@ -75,11 +75,33 @@
         }
 
         [Test]
+        public void Should_throw_bigger_value_than_maximum_refresh_delay_for_minimum_refresh_delay([Random(700, 1100, 5, Distinct = true)] double millisecondsBiggerThanMaximumRefreshDelayValue)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+            configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.FromMilliseconds(700));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.FromMilliseconds(millisecondsBiggerThanMaximumRefreshDelayValue)));
+        }
+
+        [Test]
         public void Should_set_minimum_refresh_delay_when_below_default_maximum_refresh_delay([Random(1, 1000, 5, Distinct = true)] double millisecondsSmallerThanMaximumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
             var fromMilliseconds = TimeSpan.FromMilliseconds(millisecondsSmallerThanMaximumRefreshDelayDefaultValue);
+
+            configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(fromMilliseconds);
+
+            Assert.AreEqual(fromMilliseconds, configuration.LeaseLockAcquisitionMinimumRefreshDelay);
+        }
+
+        [Test]
+        public void Should_set_minimum_refresh_delay_when_below_maximum_refresh_delay([Random(1, 700, 5, Distinct = true)] double millisecondsSmallerThanMaximumRefreshDelayValue)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+            configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.FromMilliseconds(700));
+
+            var fromMilliseconds = TimeSpan.FromMilliseconds(millisecondsSmallerThanMaximumRefreshDelayValue);
 
             configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(fromMilliseconds);
 
@@ -103,11 +125,33 @@
         }
 
         [Test]
+        public void Should_throw_smaller_value_than_minimum_refresh_delay_for_maximum_refresh_delay([Random(1, 249, 5, Distinct = true)] double millisecondsSmallerThanMinimumRefreshDelayValue)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+            configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.FromMilliseconds(250));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan.FromMilliseconds(millisecondsSmallerThanMinimumRefreshDelayValue)));
+        }
+
+        [Test]
         public void Should_set_maximum_refresh_delay_when_above_default_minimum_refresh_delay([Random(500, 1500, 5, Distinct = true)] double millisecondsBiggerThanMinimumRefreshDelayDefaultValue)
         {
             var configuration = new PessimisticLockingConfiguration();
 
             var fromMilliseconds = TimeSpan.FromMilliseconds(millisecondsBiggerThanMinimumRefreshDelayDefaultValue);
+
+            configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(fromMilliseconds);
+
+            Assert.AreEqual(fromMilliseconds, configuration.LeaseLockAcquisitionMaximumRefreshDelay);
+        }
+
+        [Test]
+        public void Should_set_maximum_refresh_delay_when_above_minimum_refresh_delay([Random(250, 1500, 5, Distinct = true)] double millisecondsBiggerThanMinimumRefreshDelayValue)
+        {
+            var configuration = new PessimisticLockingConfiguration();
+            configuration.SetLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan.FromMilliseconds(250));
+
+            var fromMilliseconds = TimeSpan.FromMilliseconds(millisecondsBiggerThanMinimumRefreshDelayValue);
 
             configuration.SetLeaseLockAcquisitionMaximumRefreshDelay(fromMilliseconds);
 

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/PessimisticLockingConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/PessimisticLockingConfiguration.cs
@@ -11,7 +11,7 @@
         /// Set saga persistence pessimistic lease lock duration. Default is 60 seconds.
         /// </summary>
         /// <param name="value">Pessimistic lease lock duration.</param>
-        public void SetPessimisticLeaseLockTime(TimeSpan value)
+        public void SetLeaseLockTime(TimeSpan value)
         {
             if (value <= TimeSpan.Zero)
             {
@@ -25,7 +25,7 @@
         /// Set saga persistence pessimistic lease lock acquisition timeout. Default is 60 seconds.
         /// </summary>
         /// <param name="value">Pessimistic lease lock acquisition duration.</param>
-        public void SetPessimisticLeaseLockAcquisitionTimeout(TimeSpan value)
+        public void SetLeaseLockAcquisitionTimeout(TimeSpan value)
         {
             if (value <= TimeSpan.Zero)
             {
@@ -39,7 +39,7 @@
         /// Set maximum saga persistence lease lock acquisition refresh delay. Default is 1000 milliseconds.
         /// </summary>
         /// <param name="value">Pessimistic lease lock acquisition maximum refresh duration.</param>
-        public void SetPessimisticLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan value)
+        public void SetLeaseLockAcquisitionMaximumRefreshDelay(TimeSpan value)
         {
             if (value <= TimeSpan.Zero)
             {
@@ -58,7 +58,7 @@
         /// Set minimum saga persistence lease lock acquisition refresh delay. Default is 500 milliseconds.
         /// </summary>
         /// <param name="value">Pessimistic lease lock acquisition minimum refresh duration.</param>
-        public void SetPessimisticLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan value)
+        public void SetLeaseLockAcquisitionMinimumRefreshDelay(TimeSpan value)
         {
             if (value <= TimeSpan.Zero)
             {

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/PessimisticLockingConfiguration.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/PessimisticLockingConfiguration.cs
@@ -77,7 +77,6 @@
         internal TimeSpan LeaseLockTime { get; private set; } = TimeSpan.FromSeconds(60);
         internal TimeSpan LeaseLockAcquisitionMaximumRefreshDelay { get; private set; } = TimeSpan.FromMilliseconds(1000);
         internal TimeSpan LeaseLockAcquisitionMinimumRefreshDelay { get; private set; } = TimeSpan.FromMilliseconds(500);
-
         internal bool PessimisticLockingEnabled { get; set; }
     }
 }


### PR DESCRIPTION
- Added a few tests
- Recognized now with the new structure the word "pessimistic" is unnecessary noise that can be removed