### PR TITLE
Add overload to provide a ContainerInformation instance

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -96,12 +96,14 @@ namespace NServiceBus.Persistence.CosmosDB
     public class TransactionInformationConfiguration
     {
         public TransactionInformationConfiguration() { }
+        public void ExtractContainerInformationFromHeader(string headerKey, NServiceBus.ContainerInformation containerInformation) { }
         public void ExtractContainerInformationFromHeader(string headerKey, System.Func<string, NServiceBus.ContainerInformation> extractor) { }
         public void ExtractContainerInformationFromHeader<TArg>(string headerKey, System.Func<string, TArg, NServiceBus.ContainerInformation> extractor, TArg extractorArgument) { }
         public void ExtractContainerInformationFromHeaders(NServiceBus.Persistence.CosmosDB.IContainerInformationFromHeadersExtractor extractor) { }
         public void ExtractContainerInformationFromHeaders(System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, NServiceBus.ContainerInformation?> extractor) { }
         public void ExtractContainerInformationFromHeaders<TArg>(System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, TArg, NServiceBus.ContainerInformation?> extractor, TArg extractorArgument) { }
         public void ExtractContainerInformationFromMessage(NServiceBus.Persistence.CosmosDB.IContainerInformationFromMessagesExtractor extractor) { }
+        public void ExtractContainerInformationFromMessage<TMessage>(NServiceBus.ContainerInformation containerInformation) { }
         public void ExtractContainerInformationFromMessage<TMessage>(System.Func<TMessage, NServiceBus.ContainerInformation> extractor) { }
         public void ExtractContainerInformationFromMessage<TMessage>(System.Func<TMessage, System.Collections.Generic.IReadOnlyDictionary<string, string>, NServiceBus.ContainerInformation> extractor) { }
         public void ExtractContainerInformationFromMessage<TMessage, TArg>(System.Func<TMessage, TArg, NServiceBus.ContainerInformation> extractor, TArg extractorArgument) { }

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/Transaction/ContainerInformationExtractorTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/Transaction/ContainerInformationExtractorTests.cs
@@ -51,6 +51,19 @@ namespace NServiceBus.Persistence.CosmosDB.Tests.Transaction
         }
 
         [Test]
+        public void Should_extract_from_header_with_fixed_container()
+        {
+            extractor.ExtractContainerInformationFromHeader("HeaderKey", new ContainerInformation("FixedValue", fakePartitionKeyPath));
+
+            var headers = new Dictionary<string, string> { { "HeaderKey", "DOES NOT MATTER" } };
+
+            var wasExtracted = extractor.TryExtract(headers, out var containerInformation);
+
+            Assert.That(wasExtracted, Is.True);
+            Assert.That(containerInformation, Is.Not.Null.And.EqualTo(new ContainerInformation("FixedValue", fakePartitionKeyPath)));
+        }
+
+        [Test]
         public void Should_extract_from_header_with_key_and_extractor()
         {
             extractor.ExtractContainerInformationFromHeader("HeaderKey",
@@ -208,6 +221,19 @@ namespace NServiceBus.Persistence.CosmosDB.Tests.Transaction
 
             Assert.That(wasExtracted, Is.True);
             Assert.That(partitionKey, Is.Not.Null.And.EqualTo(new ContainerInformation("SomeValue", fakePartitionKeyPath)));
+        }
+
+        [Test]
+        public void Should_extract_from_message_with_fixed_container()
+        {
+            extractor.ExtractContainerInformationFromMessage<MyMessage>(new ContainerInformation("FixedValue", fakePartitionKeyPath));
+
+            var message = new MyMessage { SomeId = "SomeValue" };
+
+            var wasExtracted = extractor.TryExtract(message, new Dictionary<string, string>(), out var partitionKey);
+
+            Assert.That(wasExtracted, Is.True);
+            Assert.That(partitionKey, Is.Not.Null.And.EqualTo(new ContainerInformation("FixedValue", fakePartitionKeyPath)));
         }
 
         [Test]

--- a/src/NServiceBus.Persistence.CosmosDB/Transaction/ContainerInformationExtractor.Headers.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Transaction/ContainerInformationExtractor.Headers.cs
@@ -27,6 +27,10 @@ namespace NServiceBus.Persistence.CosmosDB
             return false;
         }
 
+        public void ExtractContainerInformationFromHeader(string headerKey, ContainerInformation containerInformation) =>
+            // When moving to CSharp 9 these can be static lambdas
+            ExtractContainerInformationFromHeader(headerKey, (_, container) => container, containerInformation);
+
         public void ExtractContainerInformationFromHeader(string headerKey, Func<string, ContainerInformation> converter) =>
             // When moving to CSharp 9 these can be static lambdas
             ExtractContainerInformationFromHeader(headerKey, (headerValue, invoker) => invoker(headerValue), converter);

--- a/src/NServiceBus.Persistence.CosmosDB/Transaction/ContainerInformationExtractor.Messages.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Transaction/ContainerInformationExtractor.Messages.cs
@@ -27,6 +27,10 @@ namespace NServiceBus.Persistence.CosmosDB
             return false;
         }
 
+        public void ExtractContainerInformationFromMessage<TMessage>(ContainerInformation containerInformation) =>
+            // When moving to CSharp 9 these can be static lambdas
+            ExtractContainerInformationFromMessage<TMessage, ContainerInformation>((_, container) => container, containerInformation);
+
         public void ExtractContainerInformationFromMessage<TMessage>(Func<TMessage, ContainerInformation> extractor) =>
             // When moving to CSharp 9 these can be static lambdas
             ExtractContainerInformationFromMessage<TMessage, Func<TMessage, ContainerInformation>>((msg, _, invoker) => invoker(msg), extractor);

--- a/src/NServiceBus.Persistence.CosmosDB/Transaction/TransactionInformationConfiguration.ContainerInformation.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Transaction/TransactionInformationConfiguration.ContainerInformation.cs
@@ -9,6 +9,15 @@
     public partial class TransactionInformationConfiguration
     {
         /// <summary>
+        /// Adds an extraction rule that provides the same container information when the given <paramref name="headerKey"/> exists.
+        /// </summary>
+        /// <param name="headerKey">The header key.</param>
+        /// <param name="containerInformation">The container information to be used for the specified <paramref name="headerKey"/>.</param>
+        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
+        public void ExtractContainerInformationFromHeader(string headerKey, ContainerInformation containerInformation) =>
+            ContainerInformationExtractor.ExtractContainerInformationFromHeader(headerKey, containerInformation);
+
+        /// <summary>
         /// Adds an extraction rule that extracts the container information from a given header represented by <paramref name="headerKey"/>.
         /// </summary>
         /// <param name="headerKey">The header key.</param>
@@ -49,9 +58,19 @@
         /// <summary>
         /// Adds an instance of <see cref="IContainerInformationFromHeadersExtractor"/> to the list of header extractors.
         /// </summary>
+        /// <param name="extractor">The custom extractor.</param>
         /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
         public void ExtractContainerInformationFromHeaders(IContainerInformationFromHeadersExtractor extractor) =>
             ContainerInformationExtractor.ExtractContainerInformationFromHeaders(extractor);
+
+        /// <summary>
+        /// Adds an extraction rule that provides the same container information for a given message type <typeparamref name="TMessage"/>
+        /// </summary>
+        /// <param name="containerInformation">The container information to be used for the specified <typeparamref name="TMessage"/>.</param>
+        /// <typeparam name="TMessage">The message type to match against.</typeparam>
+        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
+        public void ExtractContainerInformationFromMessage<TMessage>(ContainerInformation containerInformation) =>
+            ContainerInformationExtractor.ExtractContainerInformationFromMessage<TMessage>(containerInformation);
 
         /// <summary>
         /// Adds an extraction rule that extracts the container information from a given message type <typeparamref name="TMessage"/>
@@ -96,6 +115,7 @@
         /// <summary>
         /// Adds an instance of <see cref="IContainerInformationFromMessagesExtractor"/> to the list of message extractors.
         /// </summary>
+        /// <param name="extractor">The custom extractor.</param>
         /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
         public void ExtractContainerInformationFromMessage(IContainerInformationFromMessagesExtractor extractor) =>
             ContainerInformationExtractor.ExtractContainerInformationFromMessage(extractor);

--- a/src/NServiceBus.Persistence.CosmosDB/Transaction/TransactionInformationConfiguration.PartitionKey.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Transaction/TransactionInformationConfiguration.PartitionKey.cs
@@ -12,54 +12,9 @@
         /// <summary>
         /// Adds an instance of <see cref="IPartitionKeyFromHeadersExtractor"/> to the list of header extractors.
         /// </summary>
+        /// <param name="extractor">The custom extractor.</param>
         /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
         public void ExtractPartitionKeyFromHeaders(IPartitionKeyFromHeadersExtractor extractor) => PartitionKeyExtractor.ExtractPartitionKeyFromHeaders(extractor);
-
-        /// <summary>
-        /// Adds an instance of <see cref="IPartitionKeyFromMessageExtractor"/> to the list of header extractors.
-        /// </summary>
-        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
-        public void ExtractPartitionKeyFromMessages(IPartitionKeyFromMessageExtractor extractor) => PartitionKeyExtractor.ExtractPartitionKeyFromMessages(extractor);
-
-        /// <summary>
-        /// Adds an extraction rule that extracts the partition key from a given message type <typeparamref name="TMessage"/>
-        /// </summary>
-        /// <param name="extractor">The extraction function.</param>
-        /// <typeparam name="TMessage">The message type to match against.</typeparam>
-        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
-        public void ExtractPartitionKeyFromMessage<TMessage>(Func<TMessage, PartitionKey> extractor) =>
-            PartitionKeyExtractor.ExtractPartitionKeyFromMessage(extractor);
-
-        /// <summary>
-        /// Adds an extraction rule that extracts the partition key from a given message type <typeparamref name="TMessage"/>
-        /// </summary>
-        /// <param name="extractor">The extraction function.</param>
-        /// <param name="extractorArgument">The argument passed as state to the <paramref name="extractor"/></param>
-        /// <typeparam name="TMessage">The message type to match against.</typeparam>
-        /// <typeparam name="TArg">The argument passed as state to the <paramref name="extractor"/></typeparam>
-        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
-        public void ExtractPartitionKeyFromMessage<TMessage, TArg>(Func<TMessage, TArg, PartitionKey> extractor, TArg extractorArgument) =>
-            PartitionKeyExtractor.ExtractPartitionKeyFromMessage(extractor, extractorArgument);
-
-        /// <summary>
-        /// Adds an extraction rule that extracts the partition key from a given message type <typeparamref name="TMessage"/>
-        /// </summary>
-        /// <param name="extractor">The extraction function.</param>
-        /// <typeparam name="TMessage">The message type to match against.</typeparam>
-        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
-        public void ExtractPartitionKeyFromMessage<TMessage>(Func<TMessage, IReadOnlyDictionary<string, string>, PartitionKey> extractor) =>
-            PartitionKeyExtractor.ExtractPartitionKeyFromMessage(extractor);
-
-        /// <summary>
-        /// Adds an extraction rule that extracts the partition key from a given message type <typeparamref name="TMessage"/>
-        /// </summary>
-        /// <param name="extractor">The extraction function.</param>
-        /// <param name="extractorArgument">The argument passed as state to the <paramref name="extractor"/></param>
-        /// <typeparam name="TMessage">The message type to match against.</typeparam>
-        /// <typeparam name="TArg">The argument passed as state to the <paramref name="extractor"/></typeparam>
-        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
-        public void ExtractPartitionKeyFromMessage<TMessage, TArg>(Func<TMessage, IReadOnlyDictionary<string, string>, TArg, PartitionKey> extractor, TArg extractorArgument) =>
-            PartitionKeyExtractor.ExtractPartitionKeyFromMessage(extractor, extractorArgument);
 
         /// <summary>
         /// Adds an extraction rule that extracts the partition key from a given header represented by <paramref name="headerKey"/>.
@@ -126,6 +81,53 @@
         /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
         public void ExtractPartitionKeyFromHeader<TArg>(string headerKey, Func<string, TArg, PartitionKey> extractor, TArg extractorArgument) =>
             PartitionKeyExtractor.ExtractPartitionKeyFromHeader(headerKey, extractor, extractorArgument);
+
+        /// <summary>
+        /// Adds an instance of <see cref="IPartitionKeyFromMessageExtractor"/> to the list of header extractors.
+        /// </summary>
+        /// <param name="extractor">The custom extractor.</param>
+        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
+        public void ExtractPartitionKeyFromMessages(IPartitionKeyFromMessageExtractor extractor) => PartitionKeyExtractor.ExtractPartitionKeyFromMessages(extractor);
+
+        /// <summary>
+        /// Adds an extraction rule that extracts the partition key from a given message type <typeparamref name="TMessage"/>
+        /// </summary>
+        /// <param name="extractor">The extraction function.</param>
+        /// <typeparam name="TMessage">The message type to match against.</typeparam>
+        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
+        public void ExtractPartitionKeyFromMessage<TMessage>(Func<TMessage, PartitionKey> extractor) =>
+            PartitionKeyExtractor.ExtractPartitionKeyFromMessage(extractor);
+
+        /// <summary>
+        /// Adds an extraction rule that extracts the partition key from a given message type <typeparamref name="TMessage"/>
+        /// </summary>
+        /// <param name="extractor">The extraction function.</param>
+        /// <param name="extractorArgument">The argument passed as state to the <paramref name="extractor"/></param>
+        /// <typeparam name="TMessage">The message type to match against.</typeparam>
+        /// <typeparam name="TArg">The argument passed as state to the <paramref name="extractor"/></typeparam>
+        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
+        public void ExtractPartitionKeyFromMessage<TMessage, TArg>(Func<TMessage, TArg, PartitionKey> extractor, TArg extractorArgument) =>
+            PartitionKeyExtractor.ExtractPartitionKeyFromMessage(extractor, extractorArgument);
+
+        /// <summary>
+        /// Adds an extraction rule that extracts the partition key from a given message type <typeparamref name="TMessage"/>
+        /// </summary>
+        /// <param name="extractor">The extraction function.</param>
+        /// <typeparam name="TMessage">The message type to match against.</typeparam>
+        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
+        public void ExtractPartitionKeyFromMessage<TMessage>(Func<TMessage, IReadOnlyDictionary<string, string>, PartitionKey> extractor) =>
+            PartitionKeyExtractor.ExtractPartitionKeyFromMessage(extractor);
+
+        /// <summary>
+        /// Adds an extraction rule that extracts the partition key from a given message type <typeparamref name="TMessage"/>
+        /// </summary>
+        /// <param name="extractor">The extraction function.</param>
+        /// <param name="extractorArgument">The argument passed as state to the <paramref name="extractor"/></param>
+        /// <typeparam name="TMessage">The message type to match against.</typeparam>
+        /// <typeparam name="TArg">The argument passed as state to the <paramref name="extractor"/></typeparam>
+        /// <remarks>Explicitly added extractors and extraction rules are executed before extractors registered on the container.</remarks>
+        public void ExtractPartitionKeyFromMessage<TMessage, TArg>(Func<TMessage, IReadOnlyDictionary<string, string>, TArg, PartitionKey> extractor, TArg extractorArgument) =>
+            PartitionKeyExtractor.ExtractPartitionKeyFromMessage(extractor, extractorArgument);
 
         internal PartitionKeyExtractor PartitionKeyExtractor { get; } = new PartitionKeyExtractor();
     }


### PR DESCRIPTION
Adds a helpful overload for simple scenarios where a `ContainerInformation` instance can be used based on the message type.