### PR TITLE
Update .net targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,6 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 6.0.x
-      - name: Setup .NET Core 3.1 runtime
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 3.1.x
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages

--- a/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests/NServiceBus.Persistence.CosmosDB.LogicalOutbox.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests/NServiceBus.Persistence.CosmosDB.NonTransactionalSagas.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/NServiceBus.Persistence.CosmosDB.PersistenceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/NServiceBus.Persistence.CosmosDB.PersistenceTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/NServiceBus.Persistence.CosmosDB.PersistenceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.PersistenceTests/NServiceBus.Persistence.CosmosDB.PersistenceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/NServiceBus.Persistence.CosmosDB.PessimisticLock.AcceptanceTests/NServiceBus.Persistence.CosmosDB.PessimisticLock.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.PessimisticLock.AcceptanceTests/NServiceBus.Persistence.CosmosDB.PessimisticLock.AcceptanceTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.CosmosDB.PessimisticLock.AcceptanceTests/NServiceBus.Persistence.CosmosDB.PessimisticLock.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.PessimisticLock.AcceptanceTests/NServiceBus.Persistence.CosmosDB.PessimisticLock.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests/NServiceBus.Persistence.CosmosDB.PhysicalOutbox.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/NServiceBus.Persistence.CosmosDB.Tests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/NServiceBus.Persistence.CosmosDB.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/NServiceBus.Persistence.CosmosDB.Tests/NServiceBus.Persistence.CosmosDB.Tests.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/NServiceBus.Persistence.CosmosDB.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 

--- a/src/NServiceBus.Persistence.CosmosDB/NServiceBus.Persistence.CosmosDB.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB/NServiceBus.Persistence.CosmosDB.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <LangVersion>8.0</LangVersion>

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosSagaIdGenerator.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosSagaIdGenerator.cs
@@ -44,7 +44,7 @@
             }
         }
 #endif
-#if NETCOREAPP
+#if NET
         static Guid DeterministicGuid(string src)
         {
             var byteCount = Encoding.UTF8.GetByteCount(src);


### PR DESCRIPTION
Removes .NET Core app 3.1 in favor of .NET 6.