### PR TITLE
Make sure PendingTransportOperations clearing doesn't leak state from previous executions

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.Tests/Outbox/PendingTransportOperationsExtensionsTests.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.Tests/Outbox/PendingTransportOperationsExtensionsTests.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.Persistence.CosmosDB.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using Routing;
+    using Transport;
+
+    [TestFixture]
+    public class PendingTransportOperationsExtensionsTests
+    {
+        [Test]
+        public void Should_clear_existing_operations()
+        {
+            var operations = new PendingTransportOperations();
+            operations.Add(new TransportOperation(
+                new OutgoingMessage("", new Dictionary<string, string>(), Array.Empty<byte>()),
+                new UnicastAddressTag("someQueue")));
+
+            operations.Clear();
+
+            Assert.That(operations.Operations, Is.Empty);
+        }
+
+        [Test]
+        public void Should_support_adding_after_clearing()
+        {
+            var operations = new PendingTransportOperations();
+            operations.Add(new TransportOperation(
+                new OutgoingMessage("1", new Dictionary<string, string>(), Array.Empty<byte>()),
+                new UnicastAddressTag("someQueue")));
+
+            operations.Clear();
+
+            operations.Add(new TransportOperation(
+                new OutgoingMessage("2", new Dictionary<string, string>(), Array.Empty<byte>()),
+                new UnicastAddressTag("someQueue")));
+
+            operations.Clear();
+
+            operations.Add(new TransportOperation(
+                new OutgoingMessage("3", new Dictionary<string, string>(), Array.Empty<byte>()),
+                new UnicastAddressTag("someQueue")));
+
+            Assert.That(operations.Operations, Has.Length.EqualTo(1));
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/PendingTransportOperationsExtensions.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/PendingTransportOperationsExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.Persistence.CosmosDB
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using Transport;
+
+    static class PendingTransportOperationsExtensions
+    {
+        static PendingTransportOperationsExtensions()
+        {
+            var field = typeof(PendingTransportOperations).GetField("operations",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var targetExp = Expression.Parameter(typeof(PendingTransportOperations), "target");
+            var fieldExp = Expression.Field(targetExp, field);
+            getter = Expression
+                .Lambda<Func<PendingTransportOperations, ConcurrentStack<TransportOperation>>>(fieldExp, targetExp)
+                .Compile();
+        }
+
+        public static void Clear(this PendingTransportOperations operations)
+        {
+            var collection = getter(operations);
+            collection.Clear();
+        }
+
+        static readonly Func<PendingTransportOperations, ConcurrentStack<TransportOperation>> getter;
+    }
+}


### PR DESCRIPTION
Backport of #386 for the `release-1.1` branch