### PR TITLE
Optimize SagaId generator to no longer allocate the intermediate string

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosSagaIdGenerator.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosSagaIdGenerator.cs
@@ -5,6 +5,9 @@
 #if NETFRAMEWORK
     using System.Runtime.InteropServices;
 #endif
+#if NET
+    using System.Runtime.CompilerServices;
+#endif
     using System.Security.Cryptography;
     using System.Text;
     using Newtonsoft.Json;
@@ -59,6 +62,7 @@
         }
 #endif
 #if NET
+        [SkipLocalsInit]
         static Guid DeterministicGuid(string sagaEntityTypeFullName, string correlationPropertyName, string serializedPropertyValue)
         {
             // sagaEntityTypeFullName_correlationPropertyName_serializedPropertyValue

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosSagaIdGenerator.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/CosmosSagaIdGenerator.cs
@@ -39,12 +39,15 @@
 
             try
             {
+                // sagaEntityTypeFullName_
                 var numberOfBytesWritten = encoding.GetBytes(sagaEntityTypeFullName.AsSpan(), stringBufferSpan);
                 stringBufferSpan[numberOfBytesWritten++] = SeparatorByte;
 
+                // sagaEntityTypeFullName_correlationPropertyName_
                 numberOfBytesWritten += encoding.GetBytes(correlationPropertyName.AsSpan(), stringBufferSpan.Slice(numberOfBytesWritten));
                 stringBufferSpan[numberOfBytesWritten++] = SeparatorByte;
 
+                // sagaEntityTypeFullName_correlationPropertyName_serializedPropertyValue
                 numberOfBytesWritten += encoding.GetBytes(serializedPropertyValue.AsSpan(), stringBufferSpan.Slice(numberOfBytesWritten));
 
                 using var sha1CryptoServiceProvider = SHA1.Create();
@@ -79,12 +82,15 @@
 
             try
             {
+                // sagaEntityTypeFullName_
                 var numberOfBytesWritten = encoding.GetBytes(sagaEntityTypeFullName.AsSpan(), stringBufferSpan);
                 stringBufferSpan[numberOfBytesWritten++] = SeparatorByte;
 
+                // sagaEntityTypeFullName_correlationPropertyName_
                 numberOfBytesWritten += encoding.GetBytes(correlationPropertyName.AsSpan(), stringBufferSpan[numberOfBytesWritten..]);
                 stringBufferSpan[numberOfBytesWritten++] = SeparatorByte;
 
+                // sagaEntityTypeFullName_correlationPropertyName_serializedPropertyValue
                 numberOfBytesWritten += encoding.GetBytes(serializedPropertyValue.AsSpan(), stringBufferSpan[numberOfBytesWritten..]);
 
                 Span<byte> hashBuffer = stackalloc byte[20];


### PR DESCRIPTION
This is a follow-up on #300. It removes the unnecessary temporary string allocation. The results are pretty nice

![image](https://user-images.githubusercontent.com/174258/176916618-7252bff3-1f75-4c8c-9c35-bbb398b55a16.png)

Existing https://github.com/Particular/NServiceBus.Persistence.CosmosDB/blob/master/src/NServiceBus.Persistence.CosmosDB.Tests/Saga/SagaIdGeneratorTests.cs verifies backward compatibility.
