### PR TITLE
Set TransactionInformationConfiguration as defaults

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB.TransactionalSession/CosmosTransactionalSession.cs
+++ b/src/NServiceBus.Persistence.CosmosDB.TransactionalSession/CosmosTransactionalSession.cs
@@ -4,13 +4,11 @@ namespace NServiceBus.TransactionalSession
 
     sealed class CosmosTransactionalSession : TransactionalSession
     {
-        public CosmosTransactionalSession()
-        {
+        public CosmosTransactionalSession() =>
             Defaults(s =>
             {
                 s.GetOrCreate<TransactionInformationConfiguration>().ExtractPartitionKeyFromHeaders(new ControlMessagePartitionKeyExtractor());
                 s.GetOrCreate<TransactionInformationConfiguration>().ExtractContainerInformationFromHeaders(new ControlMessageContainerInformationExtractor());
             });
-        }
     }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Transaction/Transaction.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Transaction/Transaction.cs
@@ -2,11 +2,13 @@ namespace NServiceBus.Persistence.CosmosDB
 {
     using Features;
 
-    class Transaction : Feature
+    sealed class Transaction : Feature
     {
+        public Transaction() => Defaults(s => s.SetDefault(new TransactionInformationConfiguration()));
+
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var configuration = context.Settings.GetOrDefault<TransactionInformationConfiguration>() ?? new TransactionInformationConfiguration();
+            var configuration = context.Settings.Get<TransactionInformationConfiguration>();
 
             context.Pipeline.Register(new TransactionInformationBeforeTheLogicalOutboxBehavior.RegisterStep(configuration.PartitionKeyExtractor, configuration.ContainerInformationExtractor));
             context.Pipeline.Register(new TransactionInformationBeforeThePhysicalOutboxBehavior.RegisterStep(configuration.PartitionKeyExtractor, configuration.ContainerInformationExtractor));


### PR DESCRIPTION
Make sure the `TransactionInformationConfiguration` is added by the defaults so that other features can add in their default implementations of partition key and container extractors without running into ordering issues.

- [ ] Release branch
- [ ] v7 branch