### PR TITLE
Revert "metadata component package yml"

### DIFF
--- a/.component-package.yml
+++ b/.component-package.yml
@@ -1,4 +1,0 @@
-ComponentType: Persistence
-ComponentPackages:
-  - Name: NServiceBus.Persistence.CosmosDB
-  - Name: NServiceBus.Persistence.CosmosDB.TransactionalSession


### PR DESCRIPTION
Reverts Particular/NServiceBus.Persistence.CosmosDB#721

Reverting this PR as component packages that are generated as part of the assets in release work flow will be read from centralized file