### PR TITLE
include obsolete version of message extractor config setting

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Config/CosmosPersistenceConfig.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Config/CosmosPersistenceConfig.cs
@@ -8,7 +8,7 @@ using Persistence.CosmosDB;
 /// <summary>
 /// Configuration extensions for Cosmos DB Core API Persistence
 /// </summary>
-public static class CosmosPersistenceConfig
+public static partial class CosmosPersistenceConfig
 {
     /// <summary>
     /// Override the default CosmosClient creation by providing a pre-configured CosmosClient

--- a/src/NServiceBus.Persistence.CosmosDB/NServiceBus.Persistence.CosmosDB.csproj
+++ b/src/NServiceBus.Persistence.CosmosDB/NServiceBus.Persistence.CosmosDB.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.53.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NServiceBus" Version="10.0.0-alpha.6" />
+    <PackageReference Include="Particular.Obsoletes" Version="1.0" PrivateAssets="All" ExcludeAssets="runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/ContainerHolderResolver.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/ContainerHolderResolver.cs
@@ -6,8 +6,8 @@ class ContainerHolderResolver(IProvideCosmosClient provideCosmosClient, Containe
 {
     public ContainerHolder ResolveAndSetIfAvailable(ContextBag context)
     {
-        var hasContainerHolder = context.TryGet<ContainerHolder>(out ContainerHolder containerHolder);
-        var hasContainerInfoInContext = context.TryGet<ContainerInformation>(out ContainerInformation containerInformation);
+        var hasContainerHolder = context.TryGet(out ContainerHolder containerHolder);
+        var hasContainerInfoInContext = context.TryGet(out ContainerInformation containerInformation);
 
         // If a custom extractor has successfully extracted container information from the message or headers,
         // we always honor that over any existing container holder in context or the default container information.
@@ -26,16 +26,7 @@ class ContainerHolderResolver(IProvideCosmosClient provideCosmosClient, Containe
             return containerHolder;
         }
 
-        ContainerInformation? information;
-
-        if (hasContainerInfoInContext)
-        {
-            information = containerInformation;
-        }
-        else
-        {
-            information = defaultContainerInformation;
-        }
+        ContainerInformation? information = hasContainerInfoInContext ? containerInformation : defaultContainerInformation;
 
         if (!information.HasValue)
         {

--- a/src/NServiceBus.Persistence.CosmosDB/obsoletes-v4.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/obsoletes-v4.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus;
+
+using System;
+using Particular.Obsoletes;
+
+public static partial class CosmosPersistenceConfig
+{
+    /// <summary>
+    /// Enables using extracted container information from the incoming message. Without this setting, only extracted container information from incoming message headers will be used
+    /// </summary>
+    [ObsoleteMetadata(
+            Message = "The EnableContainerFromMessageExtractor will become default behavior from v4.0",
+            RemoveInVersion = "5",
+            TreatAsErrorFromVersion = "4")]
+    [Obsolete("The EnableContainerFromMessageExtractor will become default behavior from v4.0. Will be removed in version 5.0.0.", false)]
+    public static PersistenceExtensions<CosmosPersistence> EnableContainerFromMessageExtractor(this PersistenceExtensions<CosmosPersistence> persistenceExtensions) => throw new NotImplementedException();
+}


### PR DESCRIPTION
[added in 3.2](https://github.com/Particular/NServiceBus.Persistence.CosmosDB/pull/908)