### PR TITLE
Enhance OCC conflict handling

### DIFF
--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxOperations.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxOperations.cs
@@ -68,5 +68,13 @@ sealed class OutboxDelete(OutboxRecord record, PartitionKey partitionKey, JsonSe
         transactionalBatch.UpsertItemStream(stream, options);
     }
 
-    public override void Conflict(TransactionalBatchOperationResult result) => throw new TransactionalBatchOperationException($"The outbox record with id '{record.Id}' could not be marked as dispatched. Response status code: {result.StatusCode}.", result);
+    public override void Conflict(TransactionalBatchOperationResult result)
+    {
+        if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency: another operation in the batch failed
+        {
+            return;
+        }
+
+        throw new TransactionalBatchOperationException($"The outbox record with id '{record.Id}' could not be marked as dispatched. Response status code: {result.StatusCode}.", result);
+    }
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxOperations.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Outbox/OutboxOperations.cs
@@ -68,13 +68,6 @@ sealed class OutboxDelete(OutboxRecord record, PartitionKey partitionKey, JsonSe
         transactionalBatch.UpsertItemStream(stream, options);
     }
 
-    public override void Conflict(TransactionalBatchOperationResult result)
-    {
-        if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency: another operation in the batch failed
-        {
-            return;
-        }
-
-        throw new TransactionalBatchOperationException($"The outbox record with id '{record.Id}' could not be marked as dispatched. Response status code: {result.StatusCode}.", result);
-    }
+    public override void Conflict(TransactionalBatchOperationResult result) =>
+        HandleConflict(result, $"The outbox record with id '{record.Id}' could not be marked as dispatched. Response status code: {result.StatusCode}.");
 }

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaOperations.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaOperations.cs
@@ -62,15 +62,8 @@ abstract class SagaOperation(IContainSagaData sagaData, PartitionKey partitionKe
 sealed class SagaSave(IContainSagaData sagaData, PartitionKey partitionKey, JsonSerializer serializer, ContextBag context)
     : SagaOperation(sagaData, partitionKey, serializer, context)
 {
-    public override void Conflict(TransactionalBatchOperationResult result)
-    {
-        if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency: another operation in the batch failed
-        {
-            return;
-        }
-
-        throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be created because a saga with the same id already exists, which happens when another message started this saga concurrently. Response status code: {result.StatusCode}.", result);
-    }
+    public override void Conflict(TransactionalBatchOperationResult result) =>
+        HandleConflict(result, $"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be created because a saga with the same id already exists, which happens when another message started this saga concurrently. Response status code: {result.StatusCode}.");
 
     public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)
     {
@@ -86,15 +79,8 @@ sealed class SagaSave(IContainSagaData sagaData, PartitionKey partitionKey, Json
 sealed class SagaUpdate(IContainSagaData sagaData, PartitionKey partitionKey, JsonSerializer serializer, ContextBag context)
     : SagaOperation(sagaData, partitionKey, serializer, context)
 {
-    public override void Conflict(TransactionalBatchOperationResult result)
-    {
-        if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency: another operation in the batch failed
-        {
-            return;
-        }
-
-        throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be updated because it was modified by another message after this message read it (optimistic concurrency conflict). Response status code: {result.StatusCode}.", result);
-    }
+    public override void Conflict(TransactionalBatchOperationResult result) =>
+        HandleConflict(result, $"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be updated because it was modified by another message after this message read it. Response status code: {result.StatusCode}.");
 
     public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)
     {
@@ -117,15 +103,8 @@ sealed class SagaUpdate(IContainSagaData sagaData, PartitionKey partitionKey, Js
 sealed class SagaDelete(IContainSagaData sagaData, PartitionKey partitionKey, ContextBag context)
     : SagaOperation(sagaData, partitionKey, null, context)
 {
-    public override void Conflict(TransactionalBatchOperationResult result)
-    {
-        if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency: another operation in the batch failed
-        {
-            return;
-        }
-
-        throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be completed because it was modified by another message after this message read it (optimistic concurrency conflict). Response status code: {result.StatusCode}.", result);
-    }
+    public override void Conflict(TransactionalBatchOperationResult result) =>
+        HandleConflict(result, $"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be completed because it was modified by another message after this message read it. Response status code: {result.StatusCode}.");
 
     public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)
     {

--- a/src/NServiceBus.Persistence.CosmosDB/Saga/SagaOperations.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/Saga/SagaOperations.cs
@@ -62,7 +62,15 @@ abstract class SagaOperation(IContainSagaData sagaData, PartitionKey partitionKe
 sealed class SagaSave(IContainSagaData sagaData, PartitionKey partitionKey, JsonSerializer serializer, ContextBag context)
     : SagaOperation(sagaData, partitionKey, serializer, context)
 {
-    public override void Conflict(TransactionalBatchOperationResult result) => throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be created. Response status code: {result.StatusCode}.", result);
+    public override void Conflict(TransactionalBatchOperationResult result)
+    {
+        if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency: another operation in the batch failed
+        {
+            return;
+        }
+
+        throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be created because a saga with the same id already exists, which happens when another message started this saga concurrently. Response status code: {result.StatusCode}.", result);
+    }
 
     public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)
     {
@@ -78,7 +86,15 @@ sealed class SagaSave(IContainSagaData sagaData, PartitionKey partitionKey, Json
 sealed class SagaUpdate(IContainSagaData sagaData, PartitionKey partitionKey, JsonSerializer serializer, ContextBag context)
     : SagaOperation(sagaData, partitionKey, serializer, context)
 {
-    public override void Conflict(TransactionalBatchOperationResult result) => throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be updated. Response status code: {result.StatusCode}.", result);
+    public override void Conflict(TransactionalBatchOperationResult result)
+    {
+        if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency: another operation in the batch failed
+        {
+            return;
+        }
+
+        throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be updated because it was modified by another message after this message read it (optimistic concurrency conflict). Response status code: {result.StatusCode}.", result);
+    }
 
     public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)
     {
@@ -101,7 +117,15 @@ sealed class SagaUpdate(IContainSagaData sagaData, PartitionKey partitionKey, Js
 sealed class SagaDelete(IContainSagaData sagaData, PartitionKey partitionKey, ContextBag context)
     : SagaOperation(sagaData, partitionKey, null, context)
 {
-    public override void Conflict(TransactionalBatchOperationResult result) => throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be completed. Response status code: {result.StatusCode}.", result);
+    public override void Conflict(TransactionalBatchOperationResult result)
+    {
+        if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency: another operation in the batch failed
+        {
+            return;
+        }
+
+        throw new TransactionalBatchOperationException($"The '{sagaData.GetType().Name}' saga with id '{sagaData.Id}' could not be completed because it was modified by another message after this message read it (optimistic concurrency conflict). Response status code: {result.StatusCode}.", result);
+    }
 
     public override void Apply(TransactionalBatch transactionalBatch, PartitionKeyPath partitionKeyPath)
     {

--- a/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/Operation.cs
+++ b/src/NServiceBus.Persistence.CosmosDB/SynchronizedStorage/Operation.cs
@@ -38,7 +38,9 @@ abstract class Operation(PartitionKey partitionKey, JsonSerializer serializer, C
     {
     }
 
-    public virtual void Conflict(TransactionalBatchOperationResult result)
+    public virtual void Conflict(TransactionalBatchOperationResult result) => HandleConflict(result);
+
+    public static void HandleConflict(TransactionalBatchOperationResult result, string conflictMessage = "")
     {
         if ((int)result.StatusCode == 424) // HttpStatusCode.FailedDependency:
         {
@@ -49,7 +51,7 @@ abstract class Operation(PartitionKey partitionKey, JsonSerializer serializer, C
         throw result.StatusCode switch
         {
             HttpStatusCode.BadRequest => new TransactionalBatchOperationException("Bad request. Likely the partition key did not match.", result),
-            HttpStatusCode.Conflict or HttpStatusCode.PreconditionFailed => new TransactionalBatchOperationException("Concurrency conflict.", result),
+            HttpStatusCode.Conflict or HttpStatusCode.PreconditionFailed => new TransactionalBatchOperationException($"Concurrency conflict. {conflictMessage}", result),
             _ => new TransactionalBatchOperationException(result)
         };
 #pragma warning restore IDE0072


### PR DESCRIPTION
Addresses https://github.com/Particular/NServiceBus.Persistence.CosmosDB/issues/377

This pull request updates conflict handling logic in the CosmosDB persistence layer to better account for batch operation failures and provide more informative error messages. The main focus is on improving how optimistic concurrency conflicts and batch dependency errors are surfaced for Outbox and Saga operations.
